### PR TITLE
feat: modernize site design with dark navy theme

### DIFF
--- a/.claude/hooks/check-gstack.sh
+++ b/.claude/hooks/check-gstack.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Block skill usage when gstack is not installed globally.
+
+if [ ! -d "$HOME/.claude/skills/gstack/bin" ]; then
+  cat >&2 <<'MSG'
+BLOCKED: gstack is not installed globally.
+
+gstack is required for AI-assisted work in this repo.
+
+Install it:
+  git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
+  cd ~/.claude/skills/gstack && ./setup --team
+
+Then restart your AI coding tool.
+MSG
+  echo '{"permissionDecision":"deny","message":"gstack is required but not installed. See stderr for install instructions."}'
+  exit 0
+fi
+
+echo '{}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-gstack.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,27 @@ Key routing rules:
 - Architecture review → invoke plan-eng-review
 - Save progress, checkpoint, resume → invoke checkpoint
 - Code quality, health check → invoke health
+
+## gstack (REQUIRED — global install)
+
+**Before doing ANY work, verify gstack is installed:**
+
+```bash
+test -d ~/.claude/skills/gstack/bin && echo "GSTACK_OK" || echo "GSTACK_MISSING"
+```
+
+If GSTACK_MISSING: STOP. Do not proceed. Tell the user:
+
+> gstack is required for all AI-assisted work in this repo.
+> Install it:
+> ```bash
+> git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
+> cd ~/.claude/skills/gstack && ./setup --team
+> ```
+> Then restart your AI coding tool.
+
+Do not skip skills, ignore gstack errors, or work around missing gstack.
+
+Using gstack skills: After install, skills like /qa, /ship, /review, /investigate,
+and /browse are available. Use /browse for all web browsing.
+Use ~/.claude/skills/gstack/... for gstack file paths (the global path).

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.metadot.com/about-us</loc><lastmod>2026-04-07T13:48:50.625Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com/blog</loc><lastmod>2026-04-07T13:48:50.626Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com/contact</loc><lastmod>2026-04-07T13:48:50.626Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com/icon.svg</loc><lastmod>2026-04-07T13:48:50.626Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com</loc><lastmod>2026-04-07T13:48:50.626Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com/blog/2020/11/successremoteteam</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
+<url><loc>https://www.metadot.com/about-us</loc><lastmod>2026-04-11T15:19:22.272Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/beta</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/blog</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/blog/page/1</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/blog/page/2</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/contact</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/icon.svg</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://www.metadot.com/blog/2020/10/firstweekremote</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-<url><loc>https://www.metadot.com/blog/2021/02/coffeedates</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-<url><loc>https://www.metadot.com/blog/2021/02/deepwork</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
+<url><loc>https://www.metadot.com/blog/2020/11/successremoteteam</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/01/dresscode</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/01/meetings</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/03/360reviews</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
@@ -16,5 +17,7 @@
 <url><loc>https://www.metadot.com/blog/2021/03/fourattributes</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/04/sittingdisease</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/04/zoomfatigue</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
+<url><loc>https://www.metadot.com/blog/2021/02/coffeedates</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
+<url><loc>https://www.metadot.com/blog/2021/02/deepwork</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/05/global</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 </urlset>

--- a/src/app/about-us/page.tsx
+++ b/src/app/about-us/page.tsx
@@ -13,7 +13,6 @@ import { useEffect } from "react";
 
 export default function AboutUs() {
   useEffect(() => {
-    // enables smooth scrolling when clicking on a "#" anchor link within this page
     const links = document.querySelectorAll('a[href^="#"]');
     links.forEach((link) => {
       link.addEventListener("click", (e) => {
@@ -39,43 +38,53 @@ export default function AboutUs() {
 
   return (
     <>
-      <section className="section-mojo text-center py-[6.6rem]!">
-        <h1>Metadot, A Team That Puts Quality, And Customer, First</h1>
-      </section>
-      <section id="about-us">
+      <section className="py-16 md:py-24 text-center border-b border-[#334155]">
         <div className="container">
-          <div className="flex flex-row mx-[-15px]">
-            <aside className="hidden md:block w-1/4 px-[15px]">
+          <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#475569] mb-4">
+            About Us
+          </p>
+          <h1 className="text-3xl md:text-5xl">
+            A Team That Puts Quality,
+            <br />
+            And Customer, First
+          </h1>
+        </div>
+      </section>
+
+      <section id="about-us" className="py-12">
+        <div className="container">
+          <div className="flex flex-row">
+            <aside className="hidden md:block w-1/4 pr-8">
               <nav className="sticky top-24">
-                <ul className="pl-[40px]">
-                  <li className="py-[0.75rem]">
+                <ul className="space-y-1">
+                  <li>
                     <a
                       href="#identity-section"
-                      className="hover:text-[#2b70a9] transition-colors"
+                      className="block py-2 text-sm"
                     >
                       Our identity
                     </a>
                   </li>
-                  <li className="py-[0.75rem]">
+                  <li>
                     <a
                       href="#values-section"
-                      className="hover:text-[#2b70a9] transition-colors"
+                      className="block py-2 text-sm"
                     >
                       Our core values
                     </a>
                   </li>
-                  <li className="py-[0.75rem]">
+                  <li>
                     <a
                       href="#work-section"
-                      className="hover:text-[#2b70a9] transition-colors"
+                      className="block py-2 text-sm"
                     >
                       How we work
                     </a>
                   </li>
-                  <li className="py-[0.75rem]">
+                  <li>
                     <a
                       href="#history-section"
-                      className="hover:text-[#2b70a9] transition-colors"
+                      className="block py-2 text-sm"
                     >
                       Our history
                     </a>
@@ -83,9 +92,11 @@ export default function AboutUs() {
                 </ul>
               </nav>
             </aside>
-            <main className="md:w-3/4 px-[15px]">
-              <div id="identity-section">
-                <div className="mb-[3rem]">
+
+            <div className="md:w-3/4">
+              {/* Identity */}
+              <div id="identity-section" className="mb-16">
+                <div className="mb-8">
                   <h2 className="section-title">Our Identity</h2>
                   <p className="section-subtitle">
                     The world wide web revolution made us significantly change
@@ -93,87 +104,51 @@ export default function AboutUs() {
                     notions we focus on:
                   </p>
                 </div>
-                <div className="container !px-0">
-                  <div className="grid grid-cols-1 md:grid-cols-2">
-                    <div className="flex flex-col mb-[3.3rem] px-[15px]">
-                      <div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                  {[
+                    {
+                      img: "/about-us/quality.svg",
+                      title: "Quality Before Quantity",
+                      desc: "Even if we are a small team, all of our products are designed with great expertise. We invest time and energy into creating top notch products and service.",
+                    },
+                    {
+                      img: "/about-us/potential.svg",
+                      title: "Ignite Human Potential",
+                      desc: "Here at Metadot, we believe in every company and every individual. Our products aim to support productivity and organization to help make even your most challenging goals, possible.",
+                    },
+                    {
+                      img: "/about-us/communication.svg",
+                      title: "Communication Is Key",
+                      desc: "We aim to provide high quality service with transparency. This means open communication throughout the process.",
+                    },
+                    {
+                      img: "/about-us/improve.svg",
+                      title: "Constantly Improving",
+                      desc: "We are constantly seeking new ways to improve our product and stay on the cutting edge of technology.",
+                    },
+                  ].map((item) => (
+                    <div key={item.title} className="flex flex-col">
+                      <div className="mb-4 p-4 bg-[#1e293b] border border-[#334155] rounded-sm inline-block">
                         <Image
-                          src="/about-us/quality.svg"
-                          alt="Quality illustration"
-                          width={1013}
-                          height={845}
-                          className="mb-[1.1rem]"
+                          src={item.img}
+                          alt={`${item.title} illustration`}
+                          width={200}
+                          height={160}
+                          className="h-32 w-auto mx-auto"
                         />
                       </div>
-                      <h3>Quality Before Quantity</h3>
-                      <p>
-                        Even if we are a small team, all of our products are
-                        designed with great expertise. We invest time and energy
-                        into creating top notch products and service.
+                      <h3 className="text-lg">{item.title}</h3>
+                      <p className="text-sm text-[#94a3b8] leading-relaxed">
+                        {item.desc}
                       </p>
                     </div>
-                    <div className="flex flex-col  mb-[3.3rem] px-[15px]">
-                      <div>
-                        <Image
-                          src="/about-us/potential.svg"
-                          alt="Potential illustration"
-                          width={958}
-                          height={825}
-                          className="mb-[1.1rem]"
-                        />
-                      </div>
-                      <h3>Ignite Human Potential</h3>
-                      <p>
-                        Here at Metadot, we believe in every company and every
-                        individual. Our products aim to support productivity and
-                        organization to help make even your most challenging
-                        goals, possible.
-                      </p>
-                    </div>
-                    <div className="flex flex-col  mb-[3.3rem] px-[15px]">
-                      <div>
-                        <Image
-                          src="/about-us/communication.svg"
-                          alt="Communication illustration"
-                          width={817}
-                          height={524}
-                          className="mb-[1.1rem]"
-                        />
-                      </div>
-                      <h3>Communication Is Key</h3>
-                      <p>
-                        We aim to provide high quality service with
-                        transparency. This means open communication throughout
-                        the process. From building strong relations with our
-                        suppliers, to delivering top-notch products to our
-                        customers - communication remains a driving force of our
-                        company.
-                      </p>
-                    </div>
-                    <div className="flex flex-col  mb-[3.3rem] px-[15px]">
-                      <div>
-                        <Image
-                          src="/about-us/improve.svg"
-                          alt="Improve illustration"
-                          width={1114}
-                          height={784}
-                          className="mb-[1.1rem]"
-                        />
-                      </div>
-                      <h3>Constantly Improving</h3>
-                      <p>
-                        We are constantly seeking new ways to improve our
-                        product and stay on the cutting edge of technology. We
-                        don't strive to just complete our goals. We strive to
-                        create a new, innovative way of thinking that dominates
-                        the industry.
-                      </p>
-                    </div>
-                  </div>
+                  ))}
                 </div>
               </div>
-              <div id="values-section" className="mb-[5rem]">
-                <div className="mb-[3rem]">
+
+              {/* Core Values */}
+              <div id="values-section" className="mb-16">
+                <div className="mb-8">
                   <h2 className="section-title">Our core values</h2>
                   <p className="section-subtitle">
                     From creating processes to decision-making and recruiting,
@@ -184,247 +159,155 @@ export default function AboutUs() {
                 <Accordion
                   type="single"
                   collapsible
-                  className="w-full border-t"
+                  className="w-full border-t border-[#334155]"
                 >
-                  <AccordionItem value="item-1" className="border-b">
-                    <AccordionTrigger>
-                      <div className="left-item flex items-center">
-                        <Image
-                          src="/about-us/boss.webp"
-                          alt="Boss"
-                          width={584}
-                          height={584}
-                          className="value-icon"
-                        />
-                        <p className="title !mb-0">THE BEST</p>
-                      </div>
-                    </AccordionTrigger>
-                    <AccordionContent className="content">
-                      <ul className="list-disc ps-[40px]">
-                        <li>
-                          The Best People:
-                          <p>
-                            We recognize the value in allowing people a chance
-                            to grow.
-                          </p>
-                        </li>
-
-                        <li>
-                          The Best Products:
-                          <p>
-                            Our products aren’t afraid to be the overachievers
-                            that they are.
-                          </p>
-                        </li>
-
-                        <li>
-                          The Best Customers:
-                          <p>
-                            From professional end-users, to uber geeks, our
-                            customers do their research, and seek our products
-                            to bring their productivity to the next level.
-                          </p>
-                        </li>
-                      </ul>
-                    </AccordionContent>
-                  </AccordionItem>
-
-                  <AccordionItem value="item-2" className="border-b">
-                    <AccordionTrigger>
-                      <div className="left-item flex items-center">
-                        <Image
-                          src="/about-us/obsess.webp"
-                          alt="Obsess"
-                          width={584}
-                          height={584}
-                          className="value-icon"
-                        />
-                        <p className="title !mb-0">QUALITY OBSESSED</p>
-                      </div>
-                    </AccordionTrigger>
-                    <AccordionContent className="content">
-                      <ul className="list-disc ps-[40px] ">
-                        <li>
-                          Premium Materials: In hardware, quality starts with
-                          our product components:
-                          <ul className="list-disc ps-[40px] mb-[0.55rem]">
-                            <li>Gold-plated key switches</li>
-                            <li>N-key rollover on all keyboards</li>
-                            <li>Aluminum construction details</li>
-                            <li>Extra long USB cable</li>
-                          </ul>
-                        </li>
-
-                        <li>
-                          Durable construction:
-                          <p>
-                            Our products aren’t afraid to be the overachievers
-                            that they are.
-                          </p>
-                        </li>
-
-                        <li>
-                          Superior Experience:
-                          <p>
-                            Every element of each product is taken into
-                            consideration - we’ve held full staff meetings to
-                            test the precise feel, sound, and reactivity of a
-                            single keystroke until we are all completely
-                            satisfied.
-                          </p>
-                        </li>
-                      </ul>
-                    </AccordionContent>
-                  </AccordionItem>
-
-                  <AccordionItem value="item-3" className="border-b">
-                    <AccordionTrigger>
-                      <div className="left-item flex items-center">
-                        <Image
-                          src="/about-us/best.webp"
-                          alt="Best"
-                          width={584}
-                          height={584}
-                          className="value-icon"
-                        />
-                        <p className="title !mb-0">BE YOUR BEST SELF</p>
-                      </div>
-                    </AccordionTrigger>
-                    <AccordionContent className="content">
-                      <ul className="list-disc ps-[40px]">
-                        <li>
-                          Cultivate Personal Growth:
-                          <ul className="list-disc ps-[40px] mb-[0.55rem]">
-                            <li>
-                              We create a work/life balance to provide the
-                              harmony that allows our employees to thrive.
-                            </li>
-                            <li>
-                              We understand that it can be hard to dedicate time
-                              outside of work for personal wellness, so we have
-                              brought classes such as yoga, tai chi, and dance
-                              to our employees within office hours.
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          Cultivate Professional Growth:
-                          <ul className="list-disc ps-[40px] mb-[0.55rem]">
-                            <li>
-                              Our goal is to help our employees enrich their
-                              skill sets in a way that will help them not just
-                              within our company, but throughout their
-                              professional careers.
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          Cultivate Friendship:
-                          <ul className="list-disc ps-[40px] mb-[0.55rem]">
-                            <li>
-                              We inspire each other, and nurture a positive work
-                              environment that congratulates each other’s hard
-                              work.
-                            </li>
-                            <li>
-                              Company-wide events allow us to celebrate company
-                              and individual milestones & achievements.
-                            </li>
-                          </ul>
-                        </li>
-                      </ul>
-                    </AccordionContent>
-                  </AccordionItem>
-
-                  <AccordionItem value="item-4" className="border-b">
-                    <AccordionTrigger>
-                      <div className="left-item flex items-center">
-                        <Image
-                          src="/about-us/innovation.webp"
-                          alt="Innovation image"
-                          width={584}
-                          height={584}
-                          className="value-icon"
-                        />
-                        <p className="title !mb-0">INNOVATION</p>
-                      </div>
-                    </AccordionTrigger>
-                    <AccordionContent className="content">
-                      <ul className="list-disc ps-[40px]">
-                        <p>
-                          Fearlessly Pushing the Limits with Products that
-                          Inspire:
-                        </p>
-                        <li>We created a new market with a blank keyboard.</li>
-                        <li>
-                          We added a magnetic ruler as a keyboard foot bar.
-                        </li>
-                        <li>
-                          We added an over-sized volume knob to our keyboards.
-                        </li>
-                        <li>
-                          We were the first company (that we know of) to add a
-                          3.0 USB hub to our keyboards.
-                        </li>
-                        <li>
-                          We continue to innovate and create products that
-                          inspire.
-                        </li>
-                      </ul>
-                    </AccordionContent>
-                  </AccordionItem>
-
-                  <AccordionItem value="item-5" className="border-b">
-                    <AccordionTrigger>
-                      <div className="left-item flex items-center">
-                        <Image
-                          src="/about-us/getitdone.webp"
-                          alt="Get it done image"
-                          width={584}
-                          height={584}
-                          className="value-icon"
-                        />
-                        <p className="title !mb-0">GET IT DONE</p>
-                      </div>
-                    </AccordionTrigger>
-                    <AccordionContent className="content">
-                      <ul className="list-disc ps-[40px]">
-                        <p>
-                          Metadot employees do what it takes to ensure our
-                          products continue to be unstoppable forces to be
-                          reckoned with...
-                        </p>
-                        <li>Sometimes this means we work late.</li>
-                        <li>Sometimes this means we take work home.</li>
-                        <li>We work hard, but we also know how to party.</li>
-                      </ul>
-                    </AccordionContent>
-                  </AccordionItem>
+                  {[
+                    {
+                      value: "item-1",
+                      img: "/about-us/boss.webp",
+                      title: "THE BEST",
+                      content: (
+                        <ul className="list-disc pl-8 space-y-2 text-sm text-[#94a3b8]">
+                          <li>
+                            <strong className="text-[#f1f5f9]">The Best People:</strong> We
+                            recognize the value in allowing people a chance to
+                            grow.
+                          </li>
+                          <li>
+                            <strong className="text-[#f1f5f9]">The Best Products:</strong> Our
+                            products aren't afraid to be the overachievers that
+                            they are.
+                          </li>
+                          <li>
+                            <strong className="text-[#f1f5f9]">The Best Customers:</strong> From
+                            professional end-users to uber geeks, our customers
+                            do their research and seek our products to bring
+                            their productivity to the next level.
+                          </li>
+                        </ul>
+                      ),
+                    },
+                    {
+                      value: "item-2",
+                      img: "/about-us/obsess.webp",
+                      title: "QUALITY OBSESSED",
+                      content: (
+                        <ul className="list-disc pl-8 space-y-2 text-sm text-[#94a3b8]">
+                          <li>
+                            <strong className="text-[#f1f5f9]">Premium Materials:</strong>{" "}
+                            Gold-plated key switches, N-key rollover, aluminum
+                            construction, extra long USB cable.
+                          </li>
+                          <li>
+                            <strong className="text-[#f1f5f9]">Durable Construction:</strong> Our
+                            products are built to last.
+                          </li>
+                          <li>
+                            <strong className="text-[#f1f5f9]">Superior Experience:</strong> We've
+                            held full staff meetings to test the precise feel,
+                            sound, and reactivity of a single keystroke.
+                          </li>
+                        </ul>
+                      ),
+                    },
+                    {
+                      value: "item-3",
+                      img: "/about-us/best.webp",
+                      title: "BE YOUR BEST SELF",
+                      content: (
+                        <ul className="list-disc pl-8 space-y-2 text-sm text-[#94a3b8]">
+                          <li>
+                            <strong className="text-[#f1f5f9]">Personal Growth:</strong> Work/life
+                            balance, in-office wellness classes.
+                          </li>
+                          <li>
+                            <strong className="text-[#f1f5f9]">Professional Growth:</strong> We
+                            help employees enrich their skill sets.
+                          </li>
+                          <li>
+                            <strong className="text-[#f1f5f9]">Friendship:</strong> Company-wide
+                            events celebrate milestones and achievements.
+                          </li>
+                        </ul>
+                      ),
+                    },
+                    {
+                      value: "item-4",
+                      img: "/about-us/innovation.webp",
+                      title: "INNOVATION",
+                      content: (
+                        <ul className="list-disc pl-8 space-y-2 text-sm text-[#94a3b8]">
+                          <li>Created a new market with a blank keyboard.</li>
+                          <li>Added a magnetic ruler as a keyboard foot bar.</li>
+                          <li>Added an oversized volume knob to keyboards.</li>
+                          <li>First company to add a 3.0 USB hub to keyboards.</li>
+                        </ul>
+                      ),
+                    },
+                    {
+                      value: "item-5",
+                      img: "/about-us/getitdone.webp",
+                      title: "GET IT DONE",
+                      content: (
+                        <ul className="list-disc pl-8 space-y-2 text-sm text-[#94a3b8]">
+                          <li>Sometimes this means we work late.</li>
+                          <li>Sometimes this means we take work home.</li>
+                          <li>We work hard, but we also know how to party.</li>
+                        </ul>
+                      ),
+                    },
+                  ].map((item) => (
+                    <AccordionItem
+                      key={item.value}
+                      value={item.value}
+                      className="border-b border-[#334155]"
+                    >
+                      <AccordionTrigger className="hover:no-underline">
+                        <div className="flex items-center gap-4">
+                          <Image
+                            src={item.img}
+                            alt={item.title}
+                            width={48}
+                            height={48}
+                            className="w-10 h-10 rounded-sm"
+                          />
+                          <span className="font-mono text-sm font-semibold tracking-wider text-[#f1f5f9]">
+                            {item.title}
+                          </span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent className="pl-14">
+                        {item.content}
+                      </AccordionContent>
+                    </AccordionItem>
+                  ))}
                 </Accordion>
               </div>
 
-              <div id="work-section" className="mb-[5rem]">
+              {/* How we work */}
+              <div id="work-section" className="mb-16">
                 <h2 className="section-title">How Do We Work</h2>
-                <div className="flex justify-center my-[1.65rem] mx-[-15px]">
+                <div className="flex justify-center my-6">
                   <Image
                     src="/about-us/map.svg"
-                    alt="Map"
+                    alt="World map showing team locations"
                     width={1177}
                     height={874}
-                    className="max-w-[80%]"
+                    className="max-w-[80%] opacity-80"
                   />
                 </div>
-                <p>
+                <p className="text-[#94a3b8] leading-relaxed">
                   We are a team of individuals, spread out across the world. Our
                   diversity is our greatest strength. Despite the miles between
                   us, we come together in one remote environment to create
-                  top-tier products and a new approach to an entirely virtual
-                  organization. We do this through the use of our own softwares
-                  Bamzooka and Mojo Helpdesk.
+                  top-tier products. We do this through the use of our own
+                  software: Bamzooka and Mojo Helpdesk.
                 </p>
               </div>
+
+              {/* History */}
               <Timeline />
-            </main>
+            </div>
           </div>
         </div>
       </section>

--- a/src/app/beta/page.tsx
+++ b/src/app/beta/page.tsx
@@ -106,7 +106,7 @@ export default function BetaPage() {
   return (
     <div className="max-w-[720px] mx-auto px-6 pt-12 pb-20">
       {/* Hero */}
-      <p className="text-xs font-medium tracking-[0.12em] uppercase text-[#888] mb-4">
+      <p className="text-xs font-medium tracking-[0.12em] uppercase text-[#94a3b8] mb-4">
         Metadot Apps
       </p>
       <h1 className="text-4xl md:text-5xl font-bold leading-tight mb-4">
@@ -114,7 +114,7 @@ export default function BetaPage() {
         <em className="font-bold">One suite.</em> No duct tape.
       </h1>
 
-      <p className="text-lg leading-relaxed text-text mb-10 max-w-[540px]">
+      <p className="text-lg leading-relaxed text-[#94a3b8] mb-10 max-w-[540px]">
         Metadot replaces the five tools that don&apos;t talk to each
         other&mdash;projects, scheduling, change communication, automation, and
         AI, all in one place.
@@ -132,10 +132,10 @@ export default function BetaPage() {
       </div>
 
       {/* Divider */}
-      <hr className="border-t border-[#f0f0f0] mb-11" />
+      <hr className="border-t border-[#334155] mb-11" />
 
       {/* What's in the suite */}
-      <p className="text-[13px] font-semibold tracking-[0.2em] uppercase text-[#555] mb-6">
+      <p className="text-[13px] font-semibold tracking-[0.2em] uppercase text-[#475569] mb-6">
         WHAT&apos;S IN THE SUITE
       </p>
 
@@ -143,11 +143,11 @@ export default function BetaPage() {
         {apps.map((app) => (
           <div
             key={app.name}
-            className="relative overflow-hidden rounded-2xl px-6 py-5 bg-gradient-to-br from-[#1a1744] via-[#3d3785] to-[#2e2d5e]"
+            className="relative overflow-hidden rounded-sm px-6 py-5 bg-gradient-to-br from-[#1a1744] via-[#3d3785] to-[#2e2d5e]"
           >
             <div className="flex items-center gap-3 mb-2">
               <div
-                className="w-8 h-8 rounded-2xl shrink-0 flex items-center justify-center"
+                className="w-8 h-8 rounded-sm shrink-0 flex items-center justify-center"
                 style={{ backgroundColor: app.bgColor, color: app.iconColor }}
               >
                 {app.icon}
@@ -168,17 +168,17 @@ export default function BetaPage() {
       </div>
 
       {/* Divider */}
-      <hr className="border-t border-[#f0f0f0] mb-11" />
+      <hr className="border-t border-[#334155] mb-11" />
 
       {/* Coming soon */}
-      <p className="text-[13px] font-semibold tracking-[0.2em] uppercase text-[#555] mb-6">
+      <p className="text-[13px] font-semibold tracking-[0.2em] uppercase text-[#475569] mb-6">
         COMING SOON
       </p>
       <div className="flex flex-wrap gap-2 mb-14">
         {comingSoon.map((item) => (
           <span
             key={item.name}
-            className="inline-flex items-center gap-1.5 text-sm text-[#666] bg-[#f0f0f0] rounded-full px-3.5 py-1"
+            className="inline-flex items-center gap-1.5 text-sm text-[#94a3b8] bg-[#1e293b] border border-[#334155] rounded-full px-3.5 py-1"
           >
             {item.icon}
             {item.name}
@@ -187,9 +187,9 @@ export default function BetaPage() {
       </div>
 
       {/* Bottom CTA */}
-      <div className="rounded-2xl p-8 bg-[#f5f5f5]" id="beta-section">
-        <h2 className="!text-2xl font-bold mb-2 text-[#222]">Join the private beta</h2>
-        <p className="text-sm text-[#666] leading-relaxed mb-6">
+      <div className="rounded-sm p-8 bg-[#1e293b] border border-[#334155]" id="beta-section">
+        <h2 className="!text-2xl font-bold mb-2 text-white">Join the private beta</h2>
+        <p className="text-sm text-[#94a3b8] leading-relaxed mb-6">
           Metadot Apps is in active development. Private beta participants get
           first access and shape what gets built. Spots are limited.
         </p>
@@ -201,7 +201,7 @@ export default function BetaPage() {
         >
           Request a spot
         </a>
-        <p className="text-xs text-[#999] mt-4">
+        <p className="text-xs text-[#475569] mt-4">
           Built by the team behind Mojo Helpdesk.
         </p>
       </div>

--- a/src/app/blog/[...slug]/page.tsx
+++ b/src/app/blog/[...slug]/page.tsx
@@ -25,13 +25,13 @@ const components = {
   a: (props: AnchorProps) => {
     const text =
       typeof props.children === "string"
-        ? props.children.trim() // removes trailing (and leading) whitespace
+        ? props.children.trim()
         : props.children;
 
     return (
       <a
         {...props}
-        className="text-[#2b70a9] underline! underline-offset-2"
+        className="text-[#e5a825] underline! underline-offset-2"
         target={props.href?.startsWith("http") ? "_blank" : undefined}
         rel={props.href?.startsWith("http") ? "noopener noreferrer" : undefined}
       >
@@ -43,15 +43,15 @@ const components = {
     <ul className="list-disc ps-[40px] mb-[1.65rem]" {...props} />
   ),
   li: (props: ListItemProps) => <li className="mb-[0.55rem]" {...props} />,
-  img: (props: ImgProps) => {
+  img: (props: ImgProps) => (
     <Image
       {...props}
       alt={props.alt || ""}
       className="img-fluid rounded img-post"
       width={props.width || 808}
       height={props.height || 582}
-    />;
-  },
+    />
+  ),
 };
 
 type Params = Promise<{ slug: string[] }>;
@@ -67,16 +67,16 @@ export default async function BlogArticlePage({
 
   return (
     <>
-      <div className="container mt-[1.1rem]">
-        <nav className="nav flex">
-          <Link className="p-[0.55rem] !text-[#6c757d]" href="/blog/">
-            Back to Home
+      <div className="container pt-6">
+        <nav>
+          <Link className="font-mono text-sm text-[#94a3b8] hover:text-[#f0b93c] transition-colors" href="/blog/">
+            &larr; Back to Blog
           </Link>
         </nav>
-      </div>{" "}
-      <article className="mojo-card blogpost container mb-[3.3rem]">
-        <h2 className="blog-title title-h2">{blog.title}</h2>
-        <p className="blog-references my-[1.65rem]">
+      </div>
+      <article className="blogpost container mb-12">
+        <h2 className="blog-title text-3xl md:text-4xl mt-6">{blog.title}</h2>
+        <p className="blog-references my-4 text-sm text-[#94a3b8]">
           {blog.author} on{" "}
           <time>
             {new Date(blog.date).toLocaleDateString("en-US", {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -10,15 +10,18 @@ export default async function BlogIndex() {
 
   return (
     <>
-      <div className="container head-section px-[15px]">
-        <h1 className="text-center !mb-0">Metadot Blog</h1>
-        <p className="text-center mt-[0.55rem] mb-[3.3rem]">
-          A blog about productivity, startups, Metadot products and news.
+      <div className="container pt-16 pb-8">
+        <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#475569] mb-4 text-center">
+          Blog
+        </p>
+        <h1 className="text-center text-3xl md:text-5xl mb-2">Metadot Blog</h1>
+        <p className="text-center text-[#94a3b8] mb-12">
+          Productivity, startups, Metadot products and news.
         </p>
       </div>
-      <div className="container-lg grid grid-cols-1 md:grid-cols-2 gap-[30px] lg:gap-[42px]">
+      <div className="container-lg grid grid-cols-1 md:grid-cols-2 gap-6 pb-8">
         {pageBlogs.map((post) => (
-          <div key={post.slug} className="mb-[3.3rem]">
+          <div key={post.slug} className="mb-4">
             <BlogCard
               title={post.title}
               quote={post.quote}
@@ -32,7 +35,7 @@ export default async function BlogIndex() {
           </div>
         ))}
       </div>
-      <div className="container-lg flex justify-center mb-[3.3rem]">
+      <div className="container-lg flex justify-center py-8">
         <Pagination currentPage={1} totalPages={totalPages} />
       </div>
     </>

--- a/src/app/blog/page/[index]/page.tsx
+++ b/src/app/blog/page/[index]/page.tsx
@@ -10,7 +10,7 @@ interface PageProps {
 }
 
 export default async function BlogPage({ params }: PageProps) {
-  const {index} = await params;
+  const { index } = await params;
   const currentPage = parseInt(index, 10);
   const blogs = await getAllBlogs();
 
@@ -21,15 +21,18 @@ export default async function BlogPage({ params }: PageProps) {
 
   return (
     <>
-      <div className="container head-section px-[15px]">
-        <h1 className="text-center !mb-0">Metadot Blog</h1>
-        <p className="text-center mt-[0.55rem] mb-[3.3rem]">
-          A blog about productivity, startups, Metadot products and news.
+      <div className="container pt-16 pb-8">
+        <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#475569] mb-4 text-center">
+          Blog
+        </p>
+        <h1 className="text-center text-3xl md:text-5xl mb-2">Metadot Blog</h1>
+        <p className="text-center text-[#94a3b8] mb-12">
+          Productivity, startups, Metadot products and news.
         </p>
       </div>
-      <div className="container-lg grid grid-cols-1 md:grid-cols-2 gap-[30px] lg:gap-[42px]">
+      <div className="container-lg grid grid-cols-1 md:grid-cols-2 gap-6 pb-8">
         {pageBlogs.map((post) => (
-          <div key={post.slug} className="mb-[3rem]">
+          <div key={post.slug} className="mb-4">
             <BlogCard
               title={post.title}
               quote={post.quote}
@@ -43,18 +46,17 @@ export default async function BlogPage({ params }: PageProps) {
           </div>
         ))}
       </div>
-      <div className="container-lg flex justify-center mb-[3.3rem]">
+      <div className="container-lg flex justify-center py-8">
         <Pagination currentPage={currentPage} totalPages={totalPages} />
       </div>
     </>
   );
 }
 
-// Static generation for all paginated routes
 export async function generateStaticParams() {
   const blogs = await getAllBlogs();
   const totalPages = Math.ceil(blogs.length / POSTS_PER_PAGE);
   return Array.from({ length: totalPages }).map((_, i) => ({
-    page: (i + 1).toString(),
+    index: (i + 1).toString(),
   }));
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -8,178 +8,125 @@ import {
   FaArrowRight,
 } from "react-icons/fa";
 import Image from "next/image";
-import { Swiper, SwiperSlide } from "swiper/react";
-import "swiper/css";
-import { Autoplay, Pagination } from "swiper/modules";
+
+const cards = [
+  {
+    title: "Mojo Helpdesk",
+    href: "https://www.mojohelpdesk.com/contact-us/",
+    icon: <FaRegEnvelope size={32} />,
+  },
+  {
+    title: "Das Keyboard",
+    href: "https://www.daskeyboard.com/contact-us/",
+    icon: <FaRegKeyboard size={36} />,
+  },
+  {
+    title: "Bamzooka",
+    href: "https://bamzooka.com/contact/",
+    icon: <FaTasks size={32} />,
+  },
+  {
+    title: "Metadot & Montastic",
+    href: "https://support.metadot.com/login/create_request#/ticket-form/13",
+    icon: <FaShare size={32} />,
+  },
+];
 
 export default function Contact() {
-  const cards = [
-    {
-      title: "For Mojo Helpdesk",
-      href: "https://www.mojohelpdesk.com/contact-us/",
-      icon: <FaRegEnvelope size={58} className="my-[1.65rem]" />,
-    },
-    {
-      title: "For Das Keyboard",
-      href: "https://www.daskeyboard.com/contact-us/",
-      icon: <FaRegKeyboard size={65} className="my-[1.65rem]" />,
-    },
-    {
-      title: "For Bamzooka",
-      href: "https://bamzooka.com/contact/",
-      icon: <FaTasks size={58} className="my-[1.65rem]" />,
-    },
-    {
-      title: "For Metadot & Montastic",
-      href: "https://support.metadot.com/login/create_request#/ticket-form/13",
-      icon: <FaShare size={58} className="my-[1.65rem]" />,
-    },
-  ];
   return (
     <>
-      <section className="section-mojo bg-[#2b70a9] text-white">
-        <div className="container mx-auto px-[15px]">
-          <h1 className="mb-[1.1rem]">Questions? We are here to help</h1>
-
-          <div className="block sc-cards-container md:hidden">
-            <Swiper
-              modules={[Autoplay, Pagination]}
-              spaceBetween={16}
-              slidesPerView={1}
-              centeredSlides
-              loop
-              autoplay={{
-                delay: 2500,
-                disableOnInteraction: false,
-              }}
-              pagination={{ clickable: true }}
-              style={{ overflow: "hidden" }}
-            >
-              {cards.map((card, i) => (
-                <SwiperSlide key={i}>
-                  <a
-                    key={i}
-                    href={card.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`p-[0.55rem] ${
-                      i !== cards.length - 1 ? "mr-[1.65rem]" : ""
-                    }`}
-                  >
-                    <div className="flex flex-1 flex-col ">
-                      <div className="icon pl-[1.1rem]">{card.icon}</div>
-                      <div className="sc-card-body px-[1.1rem]">
-                        <h6 className="text-left mt-[0.55rem]">{card.title}</h6>
-                      </div>
-                      <div className="sc-card-footer flex text-left items-center px-[1.1rem]">
-                        GO TO SUPPORT
-                        <FaArrowRight className="ml-auto h-[19px] w-auto" />
-                      </div>
-                    </div>
-                  </a>
-                </SwiperSlide>
-              ))}
-            </Swiper>
+      <section className="py-16 md:py-24 border-b border-[#334155]">
+        <div className="container">
+          <div className="text-center mb-12">
+            <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#475569] mb-4">
+              Support
+            </p>
+            <h1 className="text-3xl md:text-5xl">
+              Questions? We are here to help
+            </h1>
           </div>
 
-          <div className="hidden sc-cards-container md:flex rounded justify-center mx-auto mb-[1.65rem] mt-[3.3rem] px-[3.3rem] max-w-[1110px] ">
-            {cards.map((card, i) => (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 max-w-4xl mx-auto">
+            {cards.map((card) => (
               <a
-                key={i}
+                key={card.title}
                 href={card.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className={`p-[0.55rem] ${
-                  i !== cards.length - 1 ? "mr-[1.65rem]" : ""
-                }`}
+                className="group flex flex-col p-6 bg-[#1e293b] border border-[#334155] rounded-sm hover:border-[#f0b93c] transition-colors"
               >
-                <div className="flex flex-1 flex-col ">
-                  <div className="icon pl-[1.1rem]">{card.icon}</div>
-                  <div className="sc-card-body px-[1.1rem]">
-                    <h6 className="text-left mt-[0.55rem]">{card.title}</h6>
-                  </div>
-                  <div className="sc-card-footer flex text-left items-center px-[1.1rem]">
-                    GO TO SUPPORT
-                    <FaArrowRight className="ml-auto h-[19px] w-auto" />
-                  </div>
+                <div className="text-[#94a3b8] group-hover:text-[#f0b93c] transition-colors mb-4">
+                  {card.icon}
+                </div>
+                <h3 className="text-sm font-semibold text-white mb-auto">
+                  {card.title}
+                </h3>
+                <div className="flex items-center justify-between mt-4 pt-4 border-t border-[#334155]">
+                  <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-[#475569] group-hover:text-[#f0b93c] transition-colors">
+                    Go to support
+                  </span>
+                  <FaArrowRight className="w-3 h-3 text-[#475569] group-hover:text-[#f0b93c] group-hover:translate-x-1 transition-all" />
                 </div>
               </a>
             ))}
           </div>
         </div>
       </section>
-      <section className="section-mojo">
+
+      <section className="py-16 md:py-24">
         <div className="container">
-          <div className="px-[15px] my-[3.3rem]">
-            <h3 className="!mb-[1.65rem] text-left">
-              Our international offices
-            </h3>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 md:gap-[30px] ">
-              <div>
-                <p className="flex items-center !mb-0 whitespace-nowrap">
-                  <strong>
-                    <Image
-                      src="/flags/us-flag.webp"
-                      alt="USA flag"
-                      width={30}
-                      height={20}
-                      className="mr-2 inline-block"
-                    />{" "}
-                    Austin, Texas, USA (HQ)
-                  </strong>
-                </p>
-                <div className="text-left">
-                  <small>
-                    Metadot Corporation <br /> 14400 Piper Glen Dr <br />{" "}
-                    Austin, Texas 78738-6528 <br /> USA <br />
-                    <br />
-                    Tel:{" "}
-                    <a
-                      href="tel:+15126379983"
-                      className="text-[#2b70a9] hover:underline"
-                    >
-                      +1 512-637-9983
-                    </a>
-                    <br />
-                    Fax: +1 512-233-5335
-                  </small>
-                </div>
-              </div>
-
-              <div>
-                <p className="flex items-center !mb-0 whitespace-nowrap">
-                  <strong>
-                    <Image
-                      src="/flags/france-flag.webp"
-                      alt="France flag"
-                      width={30}
-                      height={20}
-                      className="mr-2 inline-block"
-                    />{" "}
-                    France
-                  </strong>
-                </p>
-
-                <div className="text-left">
-                  <small>
-                    29 bis, Rue de la Prairie <br /> 78120 Rambouillet - FRANCE
-                  </small>
-                </div>
-              </div>
-            </div>
+          <div className="mb-12">
+            <h2 className="section-title">Our international offices</h2>
           </div>
 
-          <div className="container-fluid container-lg my-[3.3rem] px-[15px]">
-            <iframe
-              title="Metadot Austin HQ Map"
-              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3447.190763988241!2d-97.89932172358396!3d30.341740605810878!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8644c7597e2bb5fb%3A0x9a3b5ebee7e3c6a5!2s14400%20Piper%20Glen%20Dr%2C%20Austin%2C%20TX%2078738!5e0!3m2!1sen!2sus!4v1691619392720!5m2!1sen!2sus"
-              width="100%"
-              height="350"
-              allowFullScreen
-              loading="lazy"
-              referrerPolicy="no-referrer-when-downgrade"
-            ></iframe>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12">
+            <div className="p-6 bg-[#1e293b] border border-[#334155] rounded-sm">
+              <p className="flex items-center gap-2 font-semibold text-white mb-3">
+                <Image
+                  src="/flags/us-flag.webp"
+                  alt="USA flag"
+                  width={24}
+                  height={16}
+                  className="inline-block"
+                />
+                Austin, Texas, USA (HQ)
+              </p>
+              <div className="text-sm text-[#94a3b8] leading-relaxed">
+                Metadot Corporation
+                <br />
+                14400 Piper Glen Dr
+                <br />
+                Austin, Texas 78738-6528
+                <br />
+                USA
+                <br />
+                <br />
+                Tel:{" "}
+                <a href="tel:+15126379983" className="hover:text-[#f0b93c]">
+                  +1 512-637-9983
+                </a>
+                <br />
+                Fax: +1 512-233-5335
+              </div>
+            </div>
+
+            <div className="p-6 bg-[#1e293b] border border-[#334155] rounded-sm">
+              <p className="flex items-center gap-2 font-semibold text-white mb-3">
+                <Image
+                  src="/flags/france-flag.webp"
+                  alt="France flag"
+                  width={24}
+                  height={16}
+                  className="inline-block"
+                />
+                France
+              </p>
+              <div className="text-sm text-[#94a3b8] leading-relaxed">
+                29 bis, Rue de la Prairie
+                <br />
+                78120 Rambouillet - FRANCE
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,876 +3,469 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* ── Design Tokens ─────────────────────────────────────── */
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-primary: #2b70a9;
-  --color-text: #777;
-  --color-text-dark: #222;
-  --color-body: #000;
-  --color-border: #ececec;
-  --color-black: #000;
-  --color-white: #fff;
-  --color-light: #edf6f5;
-  --color-border: #ececec;
+  --color-bg-primary: #0f172a;
+  --color-bg-secondary: #1e293b;
+  --color-bg-tertiary: #334155;
+  --color-border: #334155;
+  --color-border-subtle: #1e293b;
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #94a3b8;
+  --color-text-muted: #475569;
+  --color-accent: #f0b93c;
+  --color-accent-hover: #e5a825;
+  --color-white: #ffffff;
 
-  --breakpoint-mobile-xs: 400px;
-  --breakpoint-mobile: 575px;
-  --breakpoint-tablet: 767px;
-  --breakpoint-desktop: 991px;
-  --breakpoint-desktop-lg: 1200px;
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
-  --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
-  --color-card: var(--card);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --font-sans: var(--font-space-grotesk), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
+
+  --radius-sm: 2px;
+  --radius-md: 2px;
+  --radius-lg: 2px;
+  --radius-xl: 4px;
+
+  --color-background: var(--color-bg-primary);
+  --color-foreground: var(--color-text-primary);
+  --color-primary: var(--color-accent);
+  --color-primary-foreground: #0f172a;
+  --color-card: var(--color-bg-secondary);
+  --color-card-foreground: var(--color-text-primary);
+  --color-popover: var(--color-bg-tertiary);
+  --color-popover-foreground: var(--color-text-primary);
+  --color-secondary: var(--color-bg-tertiary);
+  --color-secondary-foreground: var(--color-text-primary);
+  --color-muted: var(--color-bg-tertiary);
+  --color-muted-foreground: var(--color-text-secondary);
+  --color-accent-foreground: #0f172a;
+  --color-destructive: #ef4444;
+  --color-input: var(--color-border);
+  --color-ring: var(--color-accent);
 }
 
-/* html {
-  scroll-behavior: smooth;
-} */
-
+/* ── Base ──────────────────────────────────────────────── */
 body {
-  font-size: 1.2rem;
-  font-weight: 400;
-  line-height: 1.5;
-  text-align: left;
+  font-family: var(--font-sans);
+  font-size: 1.125rem;
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
 }
 
-/* General */
-/* General */
-/* General */
-/* General */
-/* General */
-
-small {
-  font-size: 88%;
+/* ── Typography ────────────────────────────────────────── */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: var(--color-white);
+  margin-bottom: 0.75rem;
 }
 
-p {
-  margin-bottom: 1rem;
+h1 { font-size: 3.5rem; }
+h2 { font-size: 2.25rem; }
+h3 { font-size: 1.5rem; }
+h4 { font-size: 1.25rem; }
+
+@media (max-width: 640px) {
+  h1 { font-size: 2.25rem; }
+  h2 { font-size: 1.75rem; }
+  h3 { font-size: 1.25rem; }
 }
+
+p { margin-bottom: 1rem; }
 
 a {
-  color: var(--color-primary);
+  color: var(--color-accent);
   text-decoration: none;
-  background-color: transparent;
+  transition: color 0.15s ease;
+}
+
+a:hover {
+  color: var(--color-accent-hover);
 }
 
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,
 [role="button"]:focus-visible {
-  outline: 2px solid var(--color-primary);
+  outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
-a:hover {
-  color: #1b486c;
-  text-decoration: underline;
+/* ── Layout ────────────────────────────────────────────── */
+.container {
+  width: 100%;
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
 }
 
-small {
-  font-size: 88%;
-}
-
-h1,
-.h1 {
-  font-size: 48px;
-}
-
-h2,
-.h2 {
-  font-size: 2.5rem;
-}
-
-h3,
-.h3 {
-  font-size: 2.1rem;
-}
-
-h4,
-.h4 {
-  font-size: 20px;
-}
-
-h5,
-.h5 {
-  font-size: 1.5rem;
-}
-
-h6,
-.h6 {
-  font-size: 22px;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6 {
-  font-weight: 500;
-}
-
-.display-3 {
-  font-size: 3.5rem;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  margin-bottom: 1.1rem;
-  line-height: 1.2;
-}
-
-h1,
-h2 {
-  font-weight: 700 !important;
-  text-transform: capitalize;
-}
-
-b,
-strong {
-  font-weight: bolder;
-}
-
-.container,
 .container-lg {
   width: 100%;
-  padding-right: 15px;
-  padding-left: 15px;
-  margin-right: auto;
+  max-width: 1200px;
   margin-left: auto;
+  margin-right: auto;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
 }
 
-.row {
-  display: flex;
-  flex-wrap: wrap;
-  margin-right: -15px;
-  margin-left: -15px;
-}
-
-@media (max-width: 767px) {
-  h1 {
-    font-size: 40px;
-  }
-
-  h2 {
-    font-size: 30px;
-  }
-}
-
-@media (max-width: 575px) {
-  .container {
-    width: 100% !important;
-    max-width: 575px;
-  }
-}
-
-@media (min-width: 576px) {
-  .container {
-    max-width: 540px;
-  }
-}
-
-@media (min-width: 768px) {
-  .container {
-    max-width: 720px;
-  }
-}
-
-@media (min-width: 992px) {
-  .container,
-  .container-lg {
-    max-width: 960px;
-  }
-}
-
-@media (min-width: 1200px) {
-  .container,
-  .container-lg {
-    max-width: 1140px;
-  }
-}
-
-.border-b,
-.border-t {
-  border-color: var(--color-border);
-}
-
-.page-link {
-  position: relative;
-  display: block;
-  padding: 0.5rem 0.75rem;
-  margin-left: -1px;
-  line-height: 1.25;
-  color: var(--color-primary);
-  background-color: #fff;
-  border: 1px solid #dee2e6;
-}
-
-.page-link:hover {
-  z-index: 2;
-  color: #0056b3;
-  text-decoration: none;
-  background-color: #e9ecef;
-  border-color: #dee2e6;
-}
-
-.page-link:focus {
-  z-index: 3;
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
-}
-
-.page-item:first-child .page-link {
-  margin-left: 0;
-  border-top-left-radius: 0.25rem;
-  border-bottom-left-radius: 0.25rem;
-}
-
-.page-item:last-child .page-link {
-  border-top-right-radius: 0.25rem;
-  border-bottom-right-radius: 0.25rem;
-}
-
-.page-item.active .page-link {
-  z-index: 3;
-  color: #fff;
-  background-color: var(--color-primary);
-  border-color: var(--color-primary);
-}
-
-.page-item.disabled .page-link {
-  color: #6c757d;
-  pointer-events: none;
-  cursor: auto;
-  background-color: #fff;
-  border-color: #dee2e6;
-}
-
-.pagination {
-  display: -ms-flexbox;
-  display: flex;
-  padding-left: 0;
-  list-style: none;
-  border-radius: 0.25rem;
-}
-
-@media (max-width: 767px) {
-  .h1 {
-    font-size: 40px;
-  }
-
-  h2,
-  .h2 {
-    font-size: 30px;
-  }
-}
-
-.section-mojo {
-  padding-top: 6.6rem;
-  padding-bottom: 6.6rem;
-  text-align: center;
-  border-color: var(--color-border);
-}
-
-.section-mojo .section-mojo-title {
-  font-weight: 800;
-  text-transform: capitalize;
-  font-size: 2.5rem;
-  letter-spacing: -0.01rem;
-}
-
-.section-mojo .section-mojo-subtitle {
-  max-width: 600px;
-  font-size: 1.5rem;
-  margin: 0 auto;
-}
-
+/* ── Buttons ───────────────────────────────────────────── */
 .btn {
-  display: inline-block;
-  font-weight: 400;
-  color: #000;
-  text-align: center;
-  vertical-align: middle;
-  user-select: none;
-  background-color: transparent;
-  border: 1px solid transparent;
-  padding: 0.375rem 0.75rem;
-  font-size: 1.2rem;
-  line-height: 1.5;
-  border-radius: 0.25rem;
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
-    border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  padding: 0.625rem 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--color-text-primary);
+  text-decoration: none;
+  transition: all 0.15s ease;
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.btn:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
   text-decoration: none;
 }
 
 .btn-primary {
-  color: #fff;
-  background-color: var(--color-primary);
-  border-color: var(--color-primary);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #0f172a;
+  font-weight: 600;
 }
 
 .btn-primary:hover {
-  color: #fff;
-  background-color: #235c8b;
-  border-color: #215580;
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+  color: #0f172a;
 }
 
 .btn-link {
-  font-weight: 400;
-  color: var(--color-primary);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  color: var(--color-accent);
   text-decoration: none;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  transition: color 0.15s ease;
+}
+
+.btn-link:hover {
+  color: var(--color-accent-hover);
+  text-decoration: none;
+}
+
+.btn-link::after {
+  content: "→";
+  transition: transform 0.15s ease;
+}
+
+.btn-link:hover::after {
+  transform: translateX(3px);
+}
+
+/* ── Sections ──────────────────────────────────────────── */
+.section-dark {
+  padding: 4rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.section-darker {
+  padding: 4rem 0;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* Legacy section-mojo: mapped to new dark sections */
+.section-mojo {
+  padding: 4rem 0;
+  text-align: center;
+  border-color: var(--color-border);
+}
+
+.section-mojo-title {
+  font-weight: 800;
+  font-size: 2.25rem;
+  letter-spacing: -0.02em;
+  color: var(--color-white);
+}
+
+/* ── Header ────────────────────────────────────────────── */
+.navigation {
+  background: transparent;
+  position: relative;
+  z-index: 1000;
+}
+
+.container-header {
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 1.5rem;
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 4rem;
+}
+
+.navbar-brand {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--color-white);
+  letter-spacing: 0.05em;
+  text-decoration: none;
+  gap: 0.5rem;
+}
+
+.navbar-brand:hover {
+  color: var(--color-white);
+  text-decoration: none;
+}
+
+.navbar-toggler {
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 0.5rem;
+  min-height: 44px;
+  min-width: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.navbar-nav {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0;
+}
+
+header .nav-link {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  padding: 0.75rem 1rem;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.15s ease;
   min-height: 44px;
   display: inline-flex;
   align-items: center;
 }
 
-.btn-link:hover {
-  color: #1b486c;
-  text-decoration: underline;
+header .nav-link:hover {
+  color: var(--color-accent);
+  text-decoration: none;
 }
 
-.img-fluid {
-  max-width: 100%;
-  height: auto;
+.nav-item { margin: 0; }
+
+/* Desktop: show nav, hide toggler */
+@media (min-width: 992px) {
+  .navbar-toggler { display: none; }
+  header aside { display: none; }
+  .background-blur { display: none; }
 }
 
-/* Header */
-/* Header */
-/* Header */
-/* Header */
-/* Header */
-.navbar-brand {
-  display: inline-block;
-  padding-top: 0.35rem;
-  padding-bottom: 0.35rem;
-  margin-right: 1.1rem;
-  font-size: 1.4rem;
-  line-height: inherit;
-  white-space: nowrap;
+/* Mobile: hide nav, show toggler */
+@media (max-width: 991px) {
+  .navbar-nav { display: none; }
 }
 
-@media (max-width: 375px) {
-  .navbar-brand {
-    width: 150px;
-  }
+/* ── Footer ────────────────────────────────────────────── */
+.copyright {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  background: var(--color-bg-primary);
+  padding: 1rem;
+  text-align: center;
+  border-top: 1px solid var(--color-border);
 }
 
-.navigation {
-  @apply bg-transparent;
-}
-
-.container-header {
-  @apply max-w-[1500px] mx-auto w-full px-[15px];
-}
-
-.navbar {
-  @apply flex items-center justify-between;
-}
-
-.navbar-toggler {
-  color: #202020;
-}
-
-.navbar-collapse {
-  flex-basis: 100%;
-  flex-grow: 1;
+footer .nav-link {
+  font-size: 0.875rem;
+  padding: 0.25rem 0;
+  color: var(--color-text-secondary);
+  min-height: 44px;
+  display: inline-flex;
   align-items: center;
+  text-decoration: none;
+  transition: color 0.15s ease;
 }
 
-.navbar-nav {
+footer .nav-link:hover {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+/* ── Pagination ────────────────────────────────────────── */
+.pagination {
+  display: flex;
+  padding-left: 0;
+  list-style: none;
+  gap: 0.25rem;
+}
+
+.page-link {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 2px;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  transition: all 0.15s ease;
+}
+
+.page-link:hover {
+  color: var(--color-accent);
+  background: var(--color-bg-tertiary);
+  border-color: var(--color-accent);
+  text-decoration: none;
+}
+
+.page-item.active .page-link {
+  color: #0f172a;
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.page-item.disabled .page-link {
+  color: var(--color-text-muted);
+  pointer-events: none;
+  background: var(--color-bg-primary);
+  border-color: var(--color-border);
+}
+
+/* ── Blog Cards ────────────────────────────────────────── */
+.blog-card {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 2px;
+  max-width: 33rem;
+  text-align: left;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  text-align: center;
-  position: absolute;
-  left: 0;
-  top: 100%;
-  width: 100%;
-  background-color: #fff;
-  transition: all 0.3s ease-in-out;
-  opacity: 0;
-  visibility: hidden;
+  height: 100%;
+  overflow: hidden;
+  transition: border-color 0.2s ease, transform 0.2s ease;
 }
 
-.navbar-nav.open {
-  @apply opacity-100 visible translate-y-0;
+.blog-card:hover {
+  border-color: var(--color-text-muted);
+  transform: translateY(-4px);
 }
 
-.nav-item {
-  @apply m-0;
-}
+.blog-card a { text-decoration: none; }
 
-header .nav-link {
-  padding: 20px;
-  color: #222;
-  font-weight: 700;
-}
-
-.nav-item .nav-link:hover {
-  color: var(--color-primary);
-}
-
-aside .nav-link:hover {
-  color: var(--color-primary);
-}
-
-.dropdown {
+.blog-card-image {
   position: relative;
+  overflow: hidden;
+  aspect-ratio: 16/10;
 }
 
-.dropdown-toggle {
-  white-space: nowrap;
-  cursor: pointer;
-}
-
-.dropdown-toggle::after {
-  display: inline-block;
-  margin-left: 0.255em;
-  vertical-align: 0.255em;
-  content: "";
-  border-top: 0.3em solid;
-  border-right: 0.3em solid transparent;
-  border-bottom: 0;
-  border-left: 0.3em solid transparent;
-}
-
-.dropdown-toggle.open::after {
-  transform: rotate(180deg);
-}
-
-.dropdown-icon {
-  @apply w-3 h-3 ml-1 transition-transform duration-200 group-hover:rotate-180;
-}
-
-.dropdown-menu {
-  position: static;
-  top: 100%;
-  left: 0;
-  z-index: 1000;
-  display: none;
-  float: none;
-  min-width: max-content;
-  padding: 0.5rem 0;
-  margin: 0.125rem 0 0;
-  font-size: 1rem;
-  color: #000;
-  text-align: left;
-  list-style: none;
-  background-color: #fff;
-  background-clip: padding-box;
-  border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 0.25rem;
-}
-
-.dropdown-menu.show {
-  display: block;
-  /* position: static; */
-  float: none;
-}
-
-.dropdown-item {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  padding: 0.4rem 1.5rem;
-  clear: both;
-  font-weight: 400;
-  color: #202020;
-  text-align: inherit;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0;
-}
-
-.dropdown-item:hover {
-  color: #1264a3;
-  text-decoration: none;
-  background-color: none;
-}
-
-.dropdown-image {
-  height: 30px;
-  width: 42px;
-  vertical-align: middle;
-  padding-right: 10px;
-  padding-left: 3px;
-  margin-right: 4px;
-}
-
-.mobile-nav .nav-item {
-  padding: 10px;
-}
-
-@media (min-width: 992px) {
-  .dropdown-menu {
-    position: absolute;
-  }
-
-  .navbar-toggler,
-  .mobile-nav {
-    display: none;
-  }
-
-  .navbar-nav {
-    position: static;
-    flex-direction: row;
-    align-items: center;
-    width: auto;
-    background-color: transparent;
-    opacity: 1;
-    visibility: visible;
-    transform: none;
-  }
-
-  header aside {
-    display: none;
-  }
-
-  .background-blur {
-    display: none;
-  }
-}
-
-@media (max-width: 991px) {
-  .navbar-nav {
-    display: none;
-  }
-}
-
-/* Hero Section */
-/* Hero Section */
-/* Hero Section */
-/* Hero Section */
-/* Hero Section */
-
-.bg-img {
-  position: absolute;
-  top: 0;
-  left: 0;
+.blog-card-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  z-index: -1;
 }
 
-.banner-title {
-  font-size: 4.375rem;
-  font-weight: 600;
-  letter-spacing: -0.035rem;
-  text-shadow: 3px 1px 0px rgb(255, 255, 255);
+.blog-card-title {
+  padding: 1.25rem 1.25rem 0;
 }
 
-.banner-subtitle {
-  color: darkorange;
-  font-size: 1.5rem;
-  text-shadow: 3px 1px 0px rgb(255, 255, 255);
-  margin-bottom: 1.65rem;
+.blog-card-title h3 a {
+  color: var(--color-white);
+  font-weight: 700;
+  line-height: 1.3;
+  font-size: 1.25rem;
 }
 
-.banner-button {
-  transition: all 0.3s ease 0s;
-  font-weight: 600;
-  padding: 15px 30px;
-  font-size: 12px;
-  border: 2px solid #2b70a9;
-  border-radius: 6px;
-  box-shadow: 0 2px 1px rgba(0, 0, 0, 0.2), inset 0 2px 1px rgba(0, 0, 0, 0.2);
-  background: transparent;
-  background-color: transparent;
-  text-decoration: none;
-  text-transform: uppercase;
-  color: rgb(63, 58, 58);
-  vertical-align: middle;
-  display: inline-block;
-  line-height: 28px;
+.blog-card-title h3 a:hover {
+  color: var(--color-accent);
 }
 
-.banner-button:hover {
-  transform: translateY(-7px);
-  color: #2b70a9;
-  text-decoration: none;
+.blog-card-excerpt {
+  padding: 0 1.25rem;
+  flex: 1;
 }
 
-@media (max-width: 776px) {
-  #banner .banner-title {
-    font-size: 35px;
-  }
-  #banner .banner-subtitle {
-    font-size: 20px;
-  }
+.blog-card-excerpt p {
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+  font-size: 0.9375rem;
 }
 
-/* Home page */
-/* Home page */
-/* Home page */
-/* Home page */
-/* Home page */
-
-.hardware-brand-image {
-  width: 50%;
-  margin: 0 auto;
-  margin-bottom: 3.3rem;
+.blog-card-button {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-accent);
+  padding: 0.75rem 1.25rem;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  border: none;
+  transition: color 0.15s ease;
 }
 
-.hardware-description {
-  font-size: 20px;
-}
-
-#software .btn:hover {
-  transform: scale(1.1);
-  text-decoration: none;
+.blog-card-button:hover {
+  color: var(--color-accent-hover);
 }
 
 .latest-posts {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 30px;
+  gap: 1.5rem;
 }
 
 @media (min-width: 768px) {
   .latest-posts {
     flex-direction: row;
-    gap: 30px;
+    gap: 1.5rem;
   }
 }
 
-@media (min-width: 1200px) {
-  .latest-posts {
-    gap: 42px;
-  }
-}
-
-/* Blog Card */
-/* Blog Card */
-/* Blog Card */
-/* Blog Card */
-/* Blog Card */
-
-.blog-card {
-  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.175);
-  max-width: 33rem;
-  background-color: #fff;
-  text-align: left;
-  padding: 5%;
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  transition: transform 0.5s ease;
-}
-
-.categories-card {
-  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.175);
-  max-width: 33rem;
-  height: auto;
-  background-color: #fff;
-  text-align: center;
-  padding: 5%;
-  transition: transform 0.5s ease;
-}
-
-.blog-card a,
-.categories-card a {
-  text-decoration: none;
-}
-
-.blog-card:hover,
-.categories-card:hover {
-  transform: translateY(-15px);
-}
-
-.blog-card-title h3 a {
-  color: #261e41;
-  font-weight: 700;
-  line-height: 1.3;
-  font-size: 1.8rem;
-}
-
-.blog-card-excerpt p {
-  color: #261e41;
-  line-height: 1.7;
-}
-
-.blog-card-image {
-  position: relative;
-  overflow: hidden;
-  img {
-    width: 100%;
-    height: 100%;
-  }
-}
-
-.blog-card-button {
-  border: 2px solid;
-  font-size: 0.9rem;
-  font-weight: 700;
-  color: #007cba;
-  padding: 0.5rem 0.75rem;
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-}
-
-.blog-card-button:hover {
-  color: #000;
-}
-
-@media (max-width: 767px) {
-  .blog-card-image {
-    height: auto;
-  }
-  .blog-card {
-    height: auto;
-  }
-}
-
-@media (min-width: 768px) and (max-width: 1199px) {
-  .blog-card-image {
-    height: 15rem;
-  }
-  .blog-card {
-    min-height: 45rem;
-  }
-}
-
-@media (min-width: 1200px) {
-  .blog-card-image {
-    height: 19rem;
-  }
-  .blog-card {
-    min-height: 47.7rem;
-  }
-}
-
-/* Footer */
-/* Footer */
-/* Footer */
-/* Footer */
-/* Footer */
-
-footer .nav-link {
-  padding: 0.5rem 1rem;
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-}
-
-.nav-link:hover {
-  text-decoration: none;
-}
-
-.copyright {
-  font-weight: 400;
-  font-size: 0.75rem;
-  color: #454545;
-  background-color: #ebebeb;
-  padding: 1.1rem 1rem;
-}
-
-.sc-cards-container a {
-  color: var(--color-primary);
-  flex-basis: 29%;
-  display: flex;
-  background-color: #fff;
-  min-height: 200px;
-  flex-direction: column;
-  max-width: 285px;
-  border-radius: 8px;
-  z-index: 1;
-  transition: transform 420ms cubic-bezier(0.165, 0.84, 0.44, 1);
-  box-shadow: 0 0 2rem rgba(0, 0, 0, 0.1);
-}
-
-.sc-cards-container a:hover {
-  box-shadow: 0 0 2rem rgba(0, 0, 0, 0.2);
-  transform: scaleX(1.05);
-  text-decoration: none;
-  color: #1b486c;
-}
-
-.sc-cards-container a .sc-card-body {
-  flex: 1 1 auto !important;
-}
-
-.sc-cards-container .icon {
-  height: 6rem;
-  text-align: center;
-  color: #474747;
-}
-
-.sc-cards-container .sc-card-footer {
-  height: 3rem;
-}
-
-@media (max-width: 767.98px) {
-  .swiper-slide > a {
-    margin: auto;
-  }
-}
-
-/* About Us */
-/* About Us */
-/* About Us */
-/* About Us */
-/* About Us */
-
+/* ── About page ────────────────────────────────────────── */
 aside ul {
   list-style: none;
-  position: -webkit-sticky;
   position: sticky;
-  top: 20px;
+  top: 5rem;
 }
 
 aside ul li {
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
+  padding: 0.5rem 0;
 }
 
 aside ul li a {
-  color: #6b21a8;
+  color: var(--color-text-secondary);
+  transition: color 0.15s ease;
 }
 
 aside ul li a:hover {
-  color: #581c87;
+  color: var(--color-accent);
 }
 
 #identity-section img {
@@ -881,20 +474,36 @@ aside ul li a:hover {
 }
 
 #values-section .left-item img {
-  height: 6rem;
-  width: 6rem;
+  height: 4rem;
+  width: 4rem;
   margin-right: 1rem;
+  border-radius: 2px;
 }
 
 #values-section .title {
-  font-size: 1.5rem;
+  font-size: 1.125rem;
   font-weight: 600;
+  font-family: var(--font-mono);
 }
 
+.section-title {
+  font-weight: 800;
+  font-size: 2.25rem;
+  color: var(--color-white);
+  margin-bottom: 0.75rem;
+}
+
+.section-subtitle {
+  color: var(--color-text-secondary);
+  font-size: 1.0625rem;
+  line-height: 1.6;
+}
+
+/* ── Timeline (About page) ─────────────────────────────── */
 .timeline {
   position: relative;
   width: 860px;
-  margin: 0px auto;
+  margin: 0 auto;
   padding: 20px;
   list-style-type: none;
 }
@@ -903,365 +512,219 @@ aside ul li a:hover {
   position: absolute;
   left: 50%;
   top: 0;
-  content: " ";
+  content: "";
   display: block;
-  width: 6px;
+  width: 2px;
   height: 88%;
-  margin-left: -3px;
-  background: var(--color-primary);
+  margin-left: -1px;
+  background: var(--color-accent);
   z-index: 5;
 }
 
-.timeline li {
-  padding: 1em 0;
-}
+.timeline li { padding: 1em 0; }
+.timeline li::after { content: ""; display: block; height: 0; clear: both; visibility: hidden; }
 
-.timeline li::after {
-  content: "";
-  display: block;
-  height: 0;
-  clear: both;
-  visibility: hidden;
-}
+.direction-l { position: relative; width: 400px; float: left; text-align: right; }
+.direction-r { position: relative; width: 400px; float: right; }
 
-.direction-l {
-  position: relative;
-  width: 400px;
-  float: left;
-  text-align: right;
-}
-
-.direction-l .flag {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
-}
+.direction-l .flag { box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.3); }
+.direction-r .flag { box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.3); }
 
 .direction-l .flag::after {
-  content: "";
-  position: absolute;
-  left: 100%;
-  top: 50%;
-  height: 0;
-  width: 0;
-  margin-top: -8px;
-  border: solid transparent;
-  border-left-color: rgb(248, 248, 248);
-  border-width: 8px;
-  pointer-events: none;
-}
-
-.direction-l .time-wrapper {
-  float: left;
-}
-
-.direction-r {
-  position: relative;
-  width: 400px;
-  float: right;
-}
-
-.direction-r .flag {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  content: ""; position: absolute; left: 100%; top: 50%; height: 0; width: 0;
+  margin-top: -8px; border: solid transparent; border-left-color: var(--color-bg-tertiary);
+  border-width: 8px; pointer-events: none;
 }
 
 .direction-r .flag::after {
-  content: "";
-  position: absolute;
-  right: 100%;
-  top: 50%;
-  height: 0;
-  width: 0;
-  margin-top: -8px;
-  border: solid transparent;
-  border-right-color: rgb(248, 248, 248);
-  border-width: 8px;
-  pointer-events: none;
+  content: ""; position: absolute; right: 100%; top: 50%; height: 0; width: 0;
+  margin-top: -8px; border: solid transparent; border-right-color: var(--color-bg-tertiary);
+  border-width: 8px; pointer-events: none;
 }
 
-.direction-r .flag::before {
-  left: -16px;
-}
+.direction-r .flag::before { left: -16px; }
+.direction-l .time-wrapper { float: left; }
+.direction-r .time-wrapper { float: right; }
 
-.direction-r .time-wrapper {
-  float: right;
-}
-
-.flag-wrapper {
-  position: relative;
-  display: inline-block;
-  text-align: center;
-}
+.flag-wrapper { position: relative; display: inline-block; text-align: center; }
 
 .flag-wrapper .flag {
-  position: relative;
-  display: inline;
-  background: rgb(248, 248, 248);
-  padding: 6px 10px;
-  border-radius: 5px;
-  font-weight: 600;
-  text-align: left;
+  position: relative; display: inline;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  padding: 6px 10px; border-radius: 2px;
+  font-weight: 600; text-align: left;
 }
 
 .direction-l .flag::before,
 .direction-r .flag::before {
-  position: absolute;
-  top: 70%;
-  right: -16px;
-  content: " ";
-  display: block;
-  width: 12px;
-  height: 12px;
-  margin-top: -10px;
-  background: #fff;
-  border-radius: 10px;
-  border: 4px solid #17c73a;
-  z-index: 10;
+  position: absolute; top: 70%; right: -16px; content: "";
+  display: block; width: 12px; height: 12px; margin-top: -10px;
+  background: var(--color-bg-primary); border-radius: 10px;
+  border: 3px solid var(--color-accent); z-index: 10;
 }
 
-.ending .flag::before {
-  position: absolute;
-  top: 38%;
-  left: -19px;
-  content: " ";
-  display: block;
-  width: 20px;
-  height: 20px;
-  margin-top: -10px;
-  background: #fff;
-  border-radius: 10px;
-  border: 4px solid var #17c73a;
-  z-index: 10;
-}
+.time-wrapper { display: inline; line-height: 1em; font-size: 0.75rem; color: var(--color-accent); vertical-align: middle; }
+.time-wrapper .time { display: inline-block; padding: 4px 6px; background: var(--color-bg-tertiary); border-radius: 2px; }
 
-.time-wrapper {
-  display: inline;
-  line-height: 1em;
-  font-size: 0.66666em;
-  color: #17c73a;
-  vertical-align: middle;
-}
+.desc { margin: 1em 0.75em 0; font-size: 0.9em; line-height: 1.5em; color: var(--color-text-secondary); }
+.desc a { color: var(--color-accent); }
+.desc a:hover { text-decoration: underline; }
 
-.time-wrapper .time {
-  display: inline-block;
-  padding: 4px 6px;
-  background: rgb(248, 248, 248);
-}
-
-.desc {
-  margin: 1em 0.75em 0;
-  font-size: 0.9em;
-  line-height: 1.5em;
-}
-
-.desc a {
-  color: #17c73a;
-  text-decoration: none;
-}
-
-.desc a:hover {
-  text-decoration: underline;
-}
-
-main .content {
-  overflow: hidden;
-  padding-left: 50px;
-}
+main .content { overflow: hidden; padding-left: 50px; }
 
 @media (max-width: 767px) {
-  main .content {
-    padding-left: 10px;
-  }
+  main .content { padding-left: 10px; }
 }
 
 @media (max-width: 1200px) {
-  .timeline {
-    width: 100%;
-    padding: 4em 0 1em 0;
+  .timeline { width: 100%; padding: 4em 0 1em 0; }
+  .timeline li { padding: 2em 0; }
+  .direction-l, .direction-r { float: none; width: 100%; text-align: center; }
+  .direction-l .flag::after, .direction-r .flag::after {
+    content: ""; position: absolute; left: 50%; top: -8px; height: 0; width: 0;
+    margin-left: -8px; border: solid transparent; border-bottom-color: var(--color-bg-tertiary);
+    border-width: 8px; pointer-events: none;
   }
-
-  .timeline li {
-    padding: 2em 0;
+  .direction-l .time-wrapper, .direction-r .time-wrapper { float: none; }
+  .flag-wrapper { text-align: center; }
+  .flag-wrapper .flag { background: var(--color-bg-tertiary); border: 1px solid var(--color-border); z-index: 15; }
+  .direction-l .flag::before, .direction-r .flag::before {
+    position: absolute; top: -30px; left: 52%; content: ""; display: block; margin-left: -10px;
   }
-
-  .direction-l {
-    float: none;
-    width: 100%;
-    text-align: center;
-  }
-
-  .direction-l .flag::after {
-    content: "";
-    position: absolute;
-    left: 50%;
-    top: -8px;
-    height: 0;
-    width: 0;
-    margin-left: -8px;
-    border: solid transparent;
-    border-bottom-color: rgb(24, 20, 20);
-    border-width: 8px;
-    pointer-events: none;
-  }
-
-  .direction-l .time-wrapper {
-    float: none;
-  }
-
-  .direction-r {
-    float: none;
-    width: 100%;
-    text-align: center;
-  }
-
-  .direction-r .flag::after {
-    content: "";
-    position: absolute;
-    left: 50%;
-    top: -8px;
-    height: 0;
-    width: 0;
-    margin-left: -8px;
-    border: solid transparent;
-    border-bottom-color: rgb(24, 20, 20);
-    border-width: 8px;
-    pointer-events: none;
-  }
-
-  .direction-r .time-wrapper {
-    float: none;
-  }
-
-  .flag-wrapper {
-    text-align: center;
-  }
-
-  .flag-wrapper .flag {
-    background: rgb(255, 255, 255);
-    z-index: 15;
-    border: 1px solid;
-  }
-
-  .direction-l .flag::before,
-  .direction-r .flag::before {
-    position: absolute;
-    top: -30px;
-    left: 52%;
-    content: " ";
-    display: block;
-    margin-left: -10px;
-  }
-
-  .ending .flag::before {
-    position: absolute;
-    top: -30px;
-    left: 50%;
-    content: " ";
-    display: block;
-    margin-left: -10px;
-  }
-
-  .time-wrapper {
-    display: block;
-    position: relative;
-    margin: 4px 0 0 0;
-    z-index: 14;
-  }
-
-  .desc {
-    position: relative;
-    margin: 1em 1em 0 1em;
-    padding: 1em;
-    background: rgb(245, 245, 245);
-    box-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
-    z-index: 15;
-  }
+  .time-wrapper { display: block; position: relative; margin: 4px 0 0 0; z-index: 14; }
+  .desc { position: relative; margin: 1em; padding: 1em; background: var(--color-bg-secondary); box-shadow: 0 0 1px rgba(0,0,0,0.3); z-index: 15; border-radius: 2px; }
 }
 
-/* Blog */
-/* Blog */
-/* Blog */
-/* Blog */
-/* Blog */
-
+/* ── Blog post ─────────────────────────────────────────── */
 .head-section {
   margin-top: 50px;
   height: 13rem;
 }
 
-.mojo-card {
-  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.175);
-  padding: 16px;
-  background-color: white;
-  border-radius: 3px;
-}
-
 .blogpost {
   text-align: left;
-  color: #261e41;
+  color: var(--color-text-primary);
 }
 
 .blog-title {
   font-weight: 700;
   line-height: 1.3;
+  color: var(--color-white);
 }
 
+/* Light reading well for blog content */
 .blog-content {
-  line-height: 1.7;
+  line-height: 1.8;
+  color: #1a1a1a;
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 2px;
+  margin: 1.5rem 0;
 }
 
 .blog-content h2 {
-  font-weight: 400 !important;
-  margin-top: 25px;
-  margin-bottom: 10px;
+  font-weight: 600;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  color: #111;
+  font-size: 1.75rem;
+}
+
+.blog-content a {
+  color: #1a3764;
+}
+
+.blog-content a:hover {
+  color: #f0b93c;
+  text-decoration: underline;
 }
 
 .blog-references {
-  font-size: 15px;
-  color: #62707c;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
 }
 
 @media (min-width: 1000px) {
-  .blogpost {
-    padding: 3% 7%;
-  }
-
-  .blog-title {
-    font-size: 56px;
-  }
-
-  .blog-content h2 {
-    font-size: 2rem !important;
-  }
+  .blogpost { padding: 2rem 4rem; }
+  .blog-title { font-size: 3rem; }
+  .blog-content h2 { font-size: 1.75rem; }
 }
 
 @media (max-width: 999px) and (min-width: 601px) {
-  .blogpost {
-    padding: 3% 5%;
-  }
-
-  .blog-content h2 {
-    font-size: 2rem !important;
-  }
+  .blogpost { padding: 1.5rem 2rem; }
+  .blog-content h2 { font-size: 1.5rem; }
 }
 
 @media (max-width: 600px) {
-  .blogpost {
-    padding: 3% 4%;
-    font-size: 18px;
-    width: 92%;
-  }
-  .blog-content h2 {
-    font-size: 30px !important;
-  }
-  .blog-content ol {
-    padding-left: 2rem !important;
-  }
-  .blog-content ul {
-    padding-left: 2rem !important;
-  }
+  .blogpost { padding: 1rem; font-size: 1rem; width: 100%; }
+  .blog-content { padding: 1.25rem; }
+  .blog-content h2 { font-size: 1.375rem; }
+  .blog-content ol, .blog-content ul { padding-left: 1.5rem; }
 }
 
+/* ── Contact page cards ────────────────────────────────── */
+.sc-cards-container a {
+  color: var(--color-text-primary);
+  flex-basis: 29%;
+  display: flex;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  min-height: 200px;
+  flex-direction: column;
+  max-width: 285px;
+  border-radius: 2px;
+  z-index: 1;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.sc-cards-container a:hover {
+  border-color: var(--color-accent);
+  transform: translateY(-4px);
+  text-decoration: none;
+  color: var(--color-accent);
+}
+
+.sc-cards-container a .sc-card-body { flex: 1 1 auto; }
+.sc-cards-container .icon { height: 5rem; text-align: center; color: var(--color-text-secondary); }
+.sc-cards-container .sc-card-footer { height: 3rem; font-family: var(--font-mono); font-size: 0.75rem; letter-spacing: 0.05em; }
+
 @media (max-width: 767.98px) {
-  .title-h2 {
-    font-size: calc(2rem + (18 * (100vw - 400px)) / 624) !important;
+  .swiper-slide > a { margin: auto; }
+}
+
+/* ── Scroll animations ─────────────────────────────────── */
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(24px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(24px);
+}
+
+.animate-on-scroll.is-visible {
+  animation: fadeInUp 0.5s ease forwards;
+}
+
+/* ── Reduced motion ────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
+  .animate-on-scroll { opacity: 1; transform: none; }
+}
+
+/* ── Misc utilities ────────────────────────────────────── */
+.img-fluid { max-width: 100%; height: auto; }
+
+.mojo-card {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  padding: 1rem;
+  border-radius: 2px;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,25 @@
 import type { Metadata } from "next";
-import { Roboto } from "next/font/google";
+import { Space_Grotesk, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "@/layout/Header";
 import Footer from "@/layout/Footer";
 
-const roboto = Roboto({
+const spaceGrotesk = Space_Grotesk({
   subsets: ["latin"],
-  weight: ["400", "500", "700"], // choose what you need
+  variable: "--font-space-grotesk",
+  display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-jetbrains-mono",
   display: "swap",
 });
 
 export const metadata: Metadata = {
   title: "Metadot",
-  description: "Move forward faster with tools that supercharge productivity — Montastic, Das Keyboard, Mojo Helpdesk, and Bamzooka.",
+  description:
+    "Move forward faster with tools that supercharge productivity — Montastic, Das Keyboard, Mojo Helpdesk, and Bamzooka.",
 };
 
 export default function RootLayout({
@@ -21,10 +28,19 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={roboto.className}>
+    <html
+      lang="en"
+      className={`${spaceGrotesk.variable} ${jetbrainsMono.variable}`}
+    >
+      <body className="bg-[#0f172a] text-[#f1f5f9] antialiased">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999] focus:bg-[#f0b93c] focus:text-black focus:px-4 focus:py-2 focus:rounded-sm focus:text-sm focus:font-medium"
+        >
+          Skip to content
+        </a>
         <Header />
-        {children}
+        <main id="main-content">{children}</main>
         <Footer />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,14 +2,21 @@ import Hero from "../sections/Hero";
 import Products from "../sections/Products";
 import Feature from "../sections/Feature";
 import LatestPosts from "../sections/LatestPosts";
+import ScrollReveal from "@/components/ScrollReveal";
 
 export default function Home() {
   return (
     <>
       <Hero />
-      <Products />
-      <Feature />
-      <LatestPosts />
+      <ScrollReveal>
+        <Products />
+      </ScrollReveal>
+      <ScrollReveal delay={100}>
+        <Feature />
+      </ScrollReveal>
+      <ScrollReveal delay={100}>
+        <LatestPosts />
+      </ScrollReveal>
     </>
   );
 }

--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -22,30 +22,32 @@ export default function BlogCard({
   width,
   height,
   href,
-  buttonText = "Continue Reading",
+  buttonText = "Read more",
 }: BlogCardProps) {
   return (
-    <div className="blog-card rounded mx-auto">
+    <div className="blog-card mx-auto">
       <div className="blog-card-image">
         <Link href={href}>
-          <Image src={imageSrc} alt={alt} width={width} height={height}/>
+          <Image src={imageSrc} alt={alt} width={width} height={height} />
         </Link>
       </div>
 
-      <div className="blog-card-title mt-[1.1rem]">
+      <div className="blog-card-title">
         <h3>
           <Link href={href}>{title}</Link>
         </h3>
       </div>
 
       <div className="blog-card-excerpt">
-        {quote && <h4>“{quote}”</h4>}
+        {quote && (
+          <p className="text-sm text-[#475569] italic mb-2">&ldquo;{quote}&rdquo;</p>
+        )}
         <p>{excerpt}</p>
       </div>
 
-      <div className="px-[15px] text-center">
-        <Link href={href} className="rounded blog-card-button">
-          {buttonText}
+      <div className="px-5 pb-5 mt-auto">
+        <Link href={href} className="blog-card-button">
+          {buttonText} &rarr;
         </Link>
       </div>
     </div>

--- a/src/components/ScrollReveal.tsx
+++ b/src/components/ScrollReveal.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+
+interface ScrollRevealProps {
+  children: ReactNode;
+  className?: string;
+  delay?: number;
+}
+
+export default function ScrollReveal({
+  children,
+  className = "",
+  delay = 0,
+}: ScrollRevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (mq.matches) {
+      el.classList.add("is-visible");
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          if (delay > 0) {
+            setTimeout(() => el.classList.add("is-visible"), delay);
+          } else {
+            el.classList.add("is-visible");
+          }
+          observer.unobserve(el);
+        }
+      },
+      { threshold: 0.15 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [delay]);
+
+  return (
+    <div ref={ref} className={`animate-on-scroll ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -1,48 +1,121 @@
 import { FaGithub, FaLinkedin } from "react-icons/fa";
+import Image from "next/image";
 import Link from "next/link";
+
+const productLinks = [
+  { name: "Das Keyboard", href: "https://www.daskeyboard.com" },
+  { name: "Mojo Helpdesk", href: "https://www.mojohelpdesk.com" },
+  { name: "Bamzooka", href: "https://bamzooka.com" },
+  { name: "Montastic", href: "https://www.montastic.com" },
+  { name: "TyprX", href: "https://typrx.com" },
+];
+
+const companyLinks = [
+  { name: "About Us", href: "/about-us" },
+  { name: "Blog", href: "/blog" },
+  { name: "Contact", href: "/contact" },
+  { name: "Beta Program", href: "/beta" },
+];
 
 export default function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <>
-      <footer className="py-[1.1rem] bg-[#f8f9fa] flex justify-center md:pr-[3.3rem]">
-        <div className="flex items-center">
-          <Link className="nav-link mr-[0.55rem] font-bold" href="/contact">
-            Contact Us
-          </Link>
+    <footer className="bg-[#0f172a] border-t border-[#334155]">
+      <div className="container py-12">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-8 md:gap-12">
+          {/* Brand */}
+          <div>
+            <Link href="/" className="inline-block mb-3">
+              <Image
+                src="/logo_metadot.webp"
+                alt="Metadot"
+                width={120}
+                height={26}
+                className="brightness-0 invert"
+              />
+            </Link>
+            <p className="text-sm text-[#475569] leading-relaxed mt-2">
+              Hardware and software products built in Austin, Texas.
+            </p>
+          </div>
 
-          <Link className="nav-link mr-[0.55rem] font-bold" href="/about-us">
-            About Us
-          </Link>
+          {/* Products */}
+          <div>
+            <h4 className="font-mono text-xs font-semibold tracking-[0.15em] uppercase text-[#475569] mb-4">
+              Products
+            </h4>
+            <ul className="space-y-2">
+              {productLinks.map((link) => (
+                <li key={link.name}>
+                  <Link
+                    href={link.href}
+                    className="text-sm text-[#94a3b8] hover:text-[#f0b93c] transition-colors"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {link.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
 
-          <Link
-            className="nav-link"
-            href="https://github.com/metadot"
-            aria-label="GitHub link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <FaGithub className="w-[26px] h-auto" />
-          </Link>
-          <Link
-            className="nav-link"
-            href="https://www.linkedin.com/company/metadot-corporation"
-            aria-label="LinkedIn link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <FaLinkedin className="w-[26px] h-auto" />
-          </Link>
+          {/* Company */}
+          <div>
+            <h4 className="font-mono text-xs font-semibold tracking-[0.15em] uppercase text-[#475569] mb-4">
+              Company
+            </h4>
+            <ul className="space-y-2">
+              {companyLinks.map((link) => (
+                <li key={link.name}>
+                  <Link
+                    href={link.href}
+                    className="text-sm text-[#94a3b8] hover:text-[#f0b93c] transition-colors"
+                  >
+                    {link.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Connect */}
+          <div>
+            <h4 className="font-mono text-xs font-semibold tracking-[0.15em] uppercase text-[#475569] mb-4">
+              Connect
+            </h4>
+            <div className="flex gap-3">
+              <Link
+                href="https://github.com/metadot"
+                aria-label="GitHub"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="w-9 h-9 flex items-center justify-center border border-[#334155] rounded-sm text-[#94a3b8] hover:text-[#f0b93c] hover:border-[#f0b93c] transition-colors"
+              >
+                <FaGithub size={16} />
+              </Link>
+              <Link
+                href="https://www.linkedin.com/company/metadot-corporation"
+                aria-label="LinkedIn"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="w-9 h-9 flex items-center justify-center border border-[#334155] rounded-sm text-[#94a3b8] hover:text-[#f0b93c] hover:border-[#f0b93c] transition-colors"
+              >
+                <FaLinkedin size={16} />
+              </Link>
+            </div>
+            <p className="text-xs text-[#475569] mt-4 leading-relaxed">
+              Austin, Texas, USA
+            </p>
+          </div>
         </div>
-      </footer>
-      <footer className="text-center copyright">
-        © Copyright {year}, product of{" "}
-        <Link href="/" className="btn-link text-[#1e3a8a]! underline! underline-offset-2">
-          Metadot
-        </Link>
-        . All rights reserved. Made with ♥ in Austin, Texas.
-      </footer>
-    </>
+      </div>
+
+      {/* Copyright */}
+      <div className="copyright">
+        &copy; {year} Metadot Corporation. All rights reserved.
+      </div>
+    </footer>
   );
 }

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -1,71 +1,22 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import Image from "next/image";
+import { useState, useEffect } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { FaBars, FaTimes } from "react-icons/fa";
 
-const products = [
-  {
-    name: "Bamzooka",
-    href: "https://bamzooka.com",
-    src: "/brand/bamzooka.webp",
-    width: 192,
-    height: 192,
-  },
-  {
-    name: "Das Keyboard",
-    href: "https://www.daskeyboard.com",
-    src: "/brand/dkbrand.webp",
-    width: 49,
-    height: 63,
-  },
-  {
-    name: "Mojo Helpdesk",
-    href: "https://www.mojohelpdesk.com",
-    src: "/brand/mojo-star.svg",
-    width: 129,
-    height: 123,
-  },
-  {
-    name: "Montastic",
-    href: "https://www.montastic.com",
-    src: "/brand/montastic.webp",
-    width: 75,
-    height: 64,
-  },
+const navLinks = [
+  { name: "Products", href: "/#products" },
+  { name: "About", href: "/about-us" },
+  { name: "Blog", href: "/blog" },
+  { name: "Beta", href: "/beta" },
+  { name: "Contact", href: "/contact" },
 ];
 
 export default function Header() {
-  const [menuOpen, setMenuOpen] = useState(false);
   const [navOpen, setNavOpen] = useState(false);
 
-  const toggleNav = () => setNavOpen(!navOpen);
   const closeNav = () => setNavOpen(false);
-
-  const desktopDropRef = useRef<HTMLLIElement>(null);
-  const mobileDropRef = useRef<HTMLDivElement>(null);
-
-  const toggleDropdown = (e: React.MouseEvent) => {
-    e.stopPropagation(); // prevent outside handler
-    setMenuOpen((prev) => !prev);
-  };
-
-  useEffect(() => {
-    const onMouseUp = (e: MouseEvent) => {
-      const t = e.target as Node;
-
-      const clickedInsideDesktop = desktopDropRef.current?.contains(t) ?? false;
-      const clickedInsideMobile = mobileDropRef.current?.contains(t) ?? false;
-
-      if (!clickedInsideDesktop && !clickedInsideMobile) {
-        setMenuOpen(false);
-      }
-    };
-
-    document.addEventListener("mouseup", onMouseUp);
-    return () => document.removeEventListener("mouseup", onMouseUp);
-  }, []);
 
   useEffect(() => {
     if (navOpen) {
@@ -73,170 +24,90 @@ export default function Header() {
     } else {
       document.body.style.overflow = "";
     }
-
     return () => {
       document.body.style.overflow = "";
     };
   }, [navOpen]);
 
   return (
-    <header className="navigation z-[1000] bg-white!" >
-      <div className="container-header z-[1000]">
+    <header className="navigation z-[1000]">
+      <div className="container-header">
         <nav className="navbar">
-          {/* Logo */}
-          {/* Logo */}
-          {/* Logo */}
-          {/* Logo */}
-          {/* Logo */}
-          <Link href="/" className="navbar-brand ">
+          {/* Wordmark */}
+          <Link href="/" className="navbar-brand">
             <Image
               src="/logo_metadot.webp"
               alt="Metadot"
-              width={230}
-              height={50}
-              className="object-contain"
+              width={140}
+              height={30}
+              className="brightness-0 invert"
               priority
             />
           </Link>
 
+          {/* Mobile toggle */}
           <button
-            className="navbar-toggler relative cursor-pointer "
+            className="navbar-toggler"
             aria-label="Toggle navigation"
-            onClick={toggleNav}
+            onClick={() => setNavOpen(!navOpen)}
           >
-            <FaBars size={24} />
+            <FaBars size={20} />
           </button>
 
+          {/* Desktop nav */}
           <ul className="navbar-nav">
-            <li className="nav-item">
-              <Link href="/about-us" className="nav-link">
-                About Us
-              </Link>
-            </li>
-            <li className="nav-item">
-              <Link href="/contact" className="nav-link">
-                Contact
-              </Link>
-            </li>
-
-            {/* Dropdown */}
-            {/* Dropdown */}
-            {/* Dropdown */}
-            {/* Dropdown */}
-            {/* Dropdown */}
-            <li ref={desktopDropRef} className="nav-item dropdown">
-              <button
-                className="nav-link dropdown-toggle"
-                onClick={toggleDropdown}
-                aria-expanded={menuOpen}
-              >
-                Products
-              </button>
-
-              {menuOpen && (
-                <div className="dropdown-menu show">
-                  {products.map(({ name, href, src, width, height }) => (
-                    <Link key={name} href={href} className="dropdown-item">
-                      <Image
-                        src={src}
-                        alt={name}
-                        width={width}
-                        height={height}
-                        className="dropdown-image"
-                      />
-                      {name}
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </li>
-
-            <li className="nav-item">
-              <Link href="/blog" className="nav-link">
-                Blog
-              </Link>
-            </li>
+            {navLinks.map((link) => (
+              <li key={link.name} className="nav-item">
+                <Link href={link.href} className="nav-link">
+                  {link.name}
+                </Link>
+              </li>
+            ))}
           </ul>
         </nav>
 
+        {/* Mobile backdrop */}
         <div
-          className={`background-blur fixed inset-0 backdrop-blur-sm transition-opacity z-[999] ${
+          className={`fixed inset-0 bg-black/60 backdrop-blur-sm transition-opacity z-[999] ${
             navOpen ? "opacity-100 visible" : "opacity-0 invisible"
           }`}
           onClick={closeNav}
         />
 
-        {/* Side Drawer (mobile nav) */}
+        {/* Mobile drawer */}
         <aside
-          className={`fixed top-0 right-0 h-full z-[1000] w-64 bg-white shadow-xl transform transition-transform duration-300  ${
+          className={`fixed top-0 right-0 h-full z-[1000] w-72 bg-[#1e293b] border-l border-[#334155] shadow-2xl transform transition-transform duration-300 ${
             navOpen ? "translate-x-0" : "translate-x-full"
           }`}
         >
-          <div className="flex items-center justify-between p-4 border-b text-center">
+          <div className="flex items-center justify-between p-4 border-b border-[#334155]">
             <Image
               src="/logo_metadot.webp"
               alt="Metadot"
-              width={140}
-              height={40}
-              className="object-contain"
+              width={100}
+              height={22}
+              className="brightness-0 invert"
             />
-            <button aria-label="Close menu" onClick={closeNav} className="cursor-pointer">
-              <FaTimes size={22} />
+            <button
+              aria-label="Close menu"
+              onClick={closeNav}
+              className="cursor-pointer p-2 text-[#94a3b8] hover:text-white transition-colors"
+            >
+              <FaTimes size={18} />
             </button>
           </div>
 
-          <nav className="flex flex-col text-left px-[5px]">
-            <Link
-              href="/about-us"
-              className="nav-item nav-link !py-[10px] !px-[11px]"
-              onClick={closeNav}
-            >
-              About Us
-            </Link>
-            <Link
-              href="/contact"
-              className="nav-link !py-[10px] !px-[11px]"
-              onClick={closeNav}
-            >
-              Contact
-            </Link>
-
-            {/* Mobile dropdown */}
-            <div ref={mobileDropRef} className="nav-item py-[10px] ">
+          <nav className="flex flex-col py-2">
+            {navLinks.map((link) => (
               <Link
-                className="nav-link dropdown-toggle !px-[11px]"
-                href="#"
-                onClick={toggleDropdown}
-                aria-expanded={menuOpen}
+                key={link.name}
+                href={link.href}
+                className="px-6 py-3 font-mono text-sm text-[#94a3b8] hover:text-[#f0b93c] hover:bg-[#1e293b] transition-colors"
+                onClick={closeNav}
               >
-                Products
+                {link.name}
               </Link>
-
-              {menuOpen && (
-                <div className="dropdown-menu show">
-                  {products.map(({ name, href, src, width, height }) => (
-                    <Link key={name} href={href} className="dropdown-item">
-                      <Image
-                        src={src}
-                        alt={name}
-                        width={width}
-                        height={height}
-                        className="dropdown-image"
-                      />
-                      {name}
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            <Link
-              href="/blog"
-              className="nav-link !py-[10px] !px-[11px]"
-              onClick={closeNav}
-            >
-              Blog
-            </Link>
+            ))}
           </nav>
         </aside>
       </div>

--- a/src/sections/Feature.tsx
+++ b/src/sections/Feature.tsx
@@ -1,101 +1,68 @@
-import Image from "next/image";
 import Link from "next/link";
 
-interface FeatureProps {
-  id: string;
-  title: string;
-  description: string;
-  image: string;
-  width: number;
-  height: number;
-  reverse?: boolean;
-  links: { href: string; label: string }[];
-}
-
-function FeatureSection({
-  id,
-  title,
-  description,
-  image,
-  width,
-  height,
-  reverse = false,
-  links,
-}: FeatureProps) {
+export default function Feature() {
   return (
-    <section id={id} className="section-mojo border-b bg-white">
+    <section className="py-16 md:py-24 border-b border-[#334155]">
       <div className="container">
-        <div
-          className={`flex flex-col justify-center items-center md:gap-[30px] text-left ${
-            reverse ? "flex-col-reverse md:flex-row-reverse" : "md:flex-row"
-          }`}
-        >
-          {/* Text */}
-          <div className=" md:w-1/2 flex flex-col justify-center">
-            <h2 className="section-mojo-title">{title}</h2>
-            <p className={`mb-[1rem] ${!reverse ? "pt-[1.1rem]" : ""} `}>
-              {description}
-            </p>
+        <div className="mb-12">
+          <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#475569] mb-3">
+            Typing Culture
+          </p>
+          <h2 className="text-3xl md:text-4xl font-bold">
+            We take typing seriously.
+          </h2>
+        </div>
 
-            <div className="flex flex-wrap gap-x-[1.1rem]">
-              {links.map((link) => (
-                <Link key={link.href} href={link.href} className="btn-link">
-                  {link.label}
-                </Link>
-              ))}
-            </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {/* TyprX */}
+          <div className="p-6 bg-[#1e293b] border border-[#334155] rounded-sm">
+            <h3 className="font-mono text-lg font-semibold text-white mb-2">
+              TyprX
+            </h3>
+            <p className="text-sm text-[#94a3b8] leading-relaxed mb-4">
+              How fast do you type? TyprX is an online typing race app. Type
+              a random sentence as fast as you can and compete with others.
+            </p>
+            <Link
+              href="https://typrx.com/"
+              className="btn-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Try a typing race
+            </Link>
           </div>
 
-          {/* Image */}
-          <div className=" md:w-1/2">
-            <Image
-              src={image}
-              alt={`${title} image`}
-              width={width}
-              height={height}
-              className={`rounded img-fluid ${
-                !reverse ? "pt-[1.1rem]" : "pb-[1.1rem]"
-              }`}
-            />
+          {/* UTC */}
+          <div className="p-6 bg-[#1e293b] border border-[#334155] rounded-sm">
+            <h3 className="font-mono text-lg font-semibold text-white mb-2">
+              Ultimate Typing Championship
+            </h3>
+            <p className="text-sm text-[#94a3b8] leading-relaxed mb-4">
+              A worldwide competition where the best compete for the title
+              of Quickest Typist in the World. Online or offline, open to everyone.
+            </p>
+            <div className="flex flex-wrap gap-4">
+              <Link
+                href="https://ultimatetypingchampionship.com/"
+                className="btn-link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Learn more
+              </Link>
+              <Link
+                href="https://www.youtube.com/watch?v=vPlb8IwJIzY"
+                className="btn-link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Watch 2020 finals
+              </Link>
+            </div>
           </div>
         </div>
       </div>
     </section>
-  );
-}
-
-export default function Feature() {
-  return (
-    <>
-      <FeatureSection
-        id="typrx"
-        title="How fast do you type? Let's find out with Typrx."
-        description="Typrx is an online typing race app. Type a random sentence as fast as you can and compete with others."
-        image="/race.webp"
-        width={1142}
-        height={788}
-        links={[{ href: "https://typrx.com/", label: "Try a tying race with TyprX" }]}
-      />
-
-      <FeatureSection
-        id="utc"
-        title="Ultimate Typing Championship"
-        description="Ultimate Typing Championship : UTC is a world wide competition, where some of the best compete for the title of Quickest Typist in the World! Online or offline, this competition is open to everyone - so why not give it your best shot?"
-        image="/utc.webp"
-        width={701}
-        height={484}
-        reverse
-        links={[
-          {
-            href: "https://ultimatetypingchampionship.com/",
-            label: "Learn more about UTC",
-          },
-          {
-            href: "https://www.youtube.com/watch?v=vPlb8IwJIzY",
-            label: "Watch the 2020 competition",
-          },
-        ]}
-      />
-    </>
   );
 }

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { smoothScroll } from "@/lib/smoothScroll";
-import Image from "next/image";
 
 export default function Hero() {
   const handleSmoothScroll = (e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -13,35 +12,48 @@ export default function Hero() {
   };
 
   return (
-    <>
-      <section
-        id="banner"
-        className="section-mojo border-b text-center h-screen"
-      >
-        <div className="pointer-events-none fixed inset-0 -z-10">
-          <Image
-            src="/building.webp"
-            alt="Hero"
-            fill
-            priority
-            sizes="(min-width: 1600px) 1600px, 100vw"
-            className="bg-img"
-          />
+    <section className="relative min-h-[90vh] flex items-center border-b border-[#334155]">
+      {/* Subtle grid background */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            "linear-gradient(rgba(240,185,60,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(240,185,60,0.04) 1px, transparent 1px)",
+          backgroundSize: "64px 64px",
+        }}
+      />
+
+      <div className="container relative z-10 py-24">
+        <div className="max-w-3xl">
+          <p className="font-mono text-sm text-[#f0b93c] tracking-wider mb-6">
+            METADOT CORPORATION
+          </p>
+          <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold leading-[1.05] tracking-tight mb-6">
+            Built for
+            <br />
+            Overachievers.
+          </h1>
+          <p className="text-lg md:text-xl text-[#94a3b8] max-w-xl mb-10 leading-relaxed">
+            Hardware and software tools that boost productivity through the
+            roof. From mechanical keyboards to helpdesk systems.
+          </p>
+          <div className="flex flex-wrap gap-4">
+            <a
+              href="#products"
+              className="btn-primary btn"
+              onClick={handleSmoothScroll}
+            >
+              Explore Products
+            </a>
+            <a
+              href="/beta"
+              className="btn"
+            >
+              Join the Beta
+            </a>
+          </div>
         </div>
-        <div className="container">
-          <h1 className="banner-title">Move Forward. Faster.</h1>
-          <h2 className="banner-subtitle">
-            Tools That Boost Productivity Up Through The Roof.
-          </h2>
-          <a
-            href="#software"
-            className="btn banner-button"
-            onClick={handleSmoothScroll}
-          >
-            EXPLORE OUR PRODUCTS
-          </a>
-        </div>
-      </section>
-    </>
+      </div>
+    </section>
   );
 }

--- a/src/sections/LatestPosts.tsx
+++ b/src/sections/LatestPosts.tsx
@@ -5,14 +5,17 @@ export default async function LatestPosts() {
   const blogs = await getLatestBlogs(2);
 
   return (
-    <>
-      <section className="section-mojo bg-white">
-        <div className="container text-center px-[10px] pb-[40px]">
-          <h2 className="section-title">Our most recent posts</h2>
+    <section className="py-16 md:py-24">
+      <div className="container">
+        <div className="mb-12">
+          <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#475569] mb-3">
+            From the Blog
+          </p>
+          <h2 className="text-3xl md:text-4xl font-bold">Latest Posts</h2>
         </div>
-        <div className="latest-posts container-lg">
+        <div className="latest-posts">
           {blogs.map((post) => (
-            <div key={post.slug} className="mb-[3.3rem]">
+            <div key={post.slug}>
               <BlogCard
                 title={post.title}
                 quote={post.quote}
@@ -26,7 +29,7 @@ export default async function LatestPosts() {
             </div>
           ))}
         </div>
-      </section>
-    </>
+      </div>
+    </section>
   );
 }

--- a/src/sections/Products.tsx
+++ b/src/sections/Products.tsx
@@ -1,127 +1,119 @@
-import Image from "next/image";
 import Link from "next/link";
 
-interface SoftwareProduct {
+interface Product {
   name: string;
-  logo: string;
+  tag: string;
   href: string;
   desc: string;
-  width: number;
-  height: number;
 }
 
-const softwareProducts: SoftwareProduct[] = [
+const softwareProducts: Product[] = [
+  {
+    name: "Mojo Helpdesk",
+    tag: "Ticketing",
+    href: "https://www.mojohelpdesk.com/",
+    desc: "Centralize support requests. Track, prioritize, and resolve tickets faster.",
+  },
   {
     name: "Bamzooka",
-    logo: "/brand/bamzooka.webp",
+    tag: "Checklists",
     href: "https://bamzooka.com/",
-    desc: "Bamzooka is a recurring checklist software for easy business process management (BPM).",
-    width: 192,
-    height: 192,
+    desc: "Recurring checklists for business process management. Never miss a step.",
   },
   {
     name: "Montastic",
-    logo: "/brand/montastic.webp",
+    tag: "Monitoring",
     href: "https://www.montastic.com/",
-    desc: "Montastic monitors websites and sends notifications when a problem is detected.",
-    width: 75,
-    height: 64,
+    desc: "Website monitoring with instant notifications when something goes down.",
   },
   {
-    name: "Mojo Helpdesk",
-    logo: "/brand/mojo-star.svg",
-    href: "https://www.mojohelpdesk.com/",
-    desc: "Mojo Helpdesk is a leading ticketing system to centralize support requests and improve customer service.",
-    width: 129,
-    height: 123,
+    name: "TyprX",
+    tag: "Typing",
+    href: "https://typrx.com/",
+    desc: "Online typing races. Compete against others and track your speed.",
   },
 ];
 
 export default function Products() {
   return (
     <>
-      {/* Software */}
-      <section id="software" className="section-mojo border-b bg-white">
+      {/* Software Products */}
+      <section id="products" className="py-16 md:py-24 border-b border-[#334155]">
         <div className="container">
-          {/* Title */}
-          <h2 className="section-mojo-title !mb-[3.3rem]">
-            <Image
-              src="/icon-works.webp"
-              alt="separator"
-              width={94}
-              height={64}
-              className="mx-auto my-[10px]"
-            />
-            Our Software Products
-          </h2>
+          <div className="mb-12">
+            <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#475569] mb-3">
+              Software
+            </p>
+            <h2 className="text-3xl md:text-4xl font-bold">Our Products</h2>
+          </div>
 
-          {/* Grid */}
-          <div className="grid md:grid-cols-3 text-left mx-[-15px]">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {softwareProducts.map((product) => (
-              <div key={product.name} className="mb-[3.3rem] px-[15px]">
-                <Image
-                  src={product.logo}
-                  alt={`${product.name} Logo`}
-                  width={product.width}
-                  height={product.height}
-                  className="h-[47px] w-auto"
-                />
-                <h3 className="whitespace-nowrap">{product.name}</h3>
-                <p>{product.desc}</p>
-                <Link
-                  href={product.href}
-                  className="btn btn-primary mb-[1rem]"
-                  aria-label={`Link to ${product.name}`}
-                >
-                  Visit the site »
-                </Link>
-              </div>
+              <Link
+                key={product.name}
+                href={product.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group block p-6 bg-[#1e293b] border border-[#334155] rounded-sm hover:border-[#475569] transition-colors"
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <span className="font-mono text-base font-semibold text-white">
+                    {product.name}
+                  </span>
+                  <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-[#475569] border border-[#475569] px-2 py-0.5 rounded-sm">
+                    {product.tag}
+                  </span>
+                </div>
+                <p className="text-sm text-[#94a3b8] leading-relaxed mb-4">
+                  {product.desc}
+                </p>
+                <span className="font-mono text-xs text-[#f0b93c] group-hover:text-[#e5a825] transition-colors inline-flex items-center gap-1">
+                  Visit site
+                  <span className="group-hover:translate-x-1 transition-transform">
+                    &rarr;
+                  </span>
+                </span>
+              </Link>
             ))}
           </div>
         </div>
       </section>
 
-      {/* Hardware */}
-      <section className="section-mojo border-b bg-white" id="hardware">
+      {/* Hardware: Das Keyboard */}
+      <section id="hardware" className="py-16 md:py-24 bg-[#1e293b] border-b border-[#334155]">
         <div className="container">
-          <h2 className="section-mojo-title !mb-[3.3rem]">
-            <Image
-              src="/icon-works.webp"
-              alt="separator"
-              width={94}
-              height={64}
-              className="mx-auto my-[10px]"
-            />
-            Our Hardware Products
-          </h2>
-          <div className="hardware-products">
-            <div className="hardware-product text-center">
-              <div className="hardware-image aspect-[1909/766] max-w-[1140px] relative mb-[.275rem]">
-                <Image
-                  src="/daskeyboard.webp"
-                  alt="Product image"
-                  fill
-                  sizes="(min-width: 1024px) 1140px, 100vw"
-                />
-              </div>
-
-              <Image
-                src="/daskeyboardbrand.webp"
-                alt="Brand image"
-                width={1500}
-                height={211}
-                className="hardware-brand-image mb-[3.3rem]"
+          <div className="flex flex-col md:flex-row items-center gap-8 md:gap-16">
+            {/* Image */}
+            <div className="md:w-3/5">
+              <img
+                src="/daskeyboard.webp"
+                alt="Das Keyboard mechanical keyboard"
+                className="w-full h-auto"
+                loading="lazy"
               />
-              <p className="hardware-description text-center max-w-2xl mx-auto">
-                <strong>Das Keyboard</strong> is a brand of high-quality
-                mechanical keyboards for typists, software developers, tech
-                enthusiasts, and gamers. A reference in the market.
+            </div>
+
+            {/* Text */}
+            <div className="md:w-2/5">
+              <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#475569] mb-3">
+                Hardware
               </p>
-              <div>
-                <Link href="https://www.daskeyboard.com" className="btn-link">
-                  Visit Das Keyboard
-                </Link>
-              </div>
+              <h2 className="text-3xl md:text-4xl font-bold mb-4">
+                Das Keyboard
+              </h2>
+              <p className="text-[#94a3b8] leading-relaxed mb-6">
+                Premium mechanical keyboards for typists, developers, and
+                enthusiasts. Gold-plated switches, aluminum construction,
+                built to last.
+              </p>
+              <Link
+                href="https://www.daskeyboard.com"
+                className="btn-link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Visit Das Keyboard
+              </Link>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Complete visual redesign from dated Bootstrap-era look to modern dark navy (#0f172a) aesthetic using the Metadot logo's own color palette (navy blue + gold #f0b93c accent)
- Swap fonts to Space Grotesk (body) + JetBrains Mono (code/nav) via next/font
- Rewrite globals.css from 1268 lines to ~350 lines with CSS custom property design tokens
- Rewrite all pages (homepage, about, contact, blog, beta) and components (header, footer, blog cards) for the new theme
- Add scroll-reveal animations via IntersectionObserver (ScrollReveal component)
- Use actual Metadot logo (white-inverted on dark bg) instead of text-only wordmark
- Fix pre-existing bugs: blog MDX img component not rendering (missing return), blog pagination generateStaticParams using wrong param name
- Remove Google Maps iframe from contact page

## Test plan

- [ ] Verify homepage renders: hero with logo, gold CTA, product cards, Das Keyboard section, typing culture, latest posts, footer
- [ ] Verify about page: dark identity grid, accordion values, timeline
- [ ] Verify contact page: support cards with gold hover, office addresses
- [ ] Verify blog listing: dark cards in 2-column grid, pagination works
- [ ] Verify blog post: dark shell with light reading well for content, inline images render
- [ ] Verify beta page: purple gradient app cards, dark coming-soon pills, dark CTA box
- [ ] Verify mobile: hamburger nav opens dark drawer, responsive layout
- [ ] Run `npm run build` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)