### PR TITLE
fix: improve low-contrast text visibility across site

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "cp $CONDUCTOR_ROOT_PATH/.env.local .env.local && cp -r $CONDUCTOR_ROOT_PATH/.vercel . && pnpm install",
+    "setup": "test -f $CONDUCTOR_ROOT_PATH/.env.local && cp $CONDUCTOR_ROOT_PATH/.env.local .env.local; test -d $CONDUCTOR_ROOT_PATH/.vercel && cp -r $CONDUCTOR_ROOT_PATH/.vercel .; pnpm install",
     "run": "pnpm run dev",
     "archive": ""
   }

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.metadot.com/about-us</loc><lastmod>2026-04-11T15:19:22.272Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com/beta</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com/blog</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com/blog/page/1</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com/blog/page/2</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com/contact</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com/icon.svg</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.metadot.com</loc><lastmod>2026-04-11T15:19:22.273Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/about-us</loc><lastmod>2026-04-11T17:34:11.345Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/beta</loc><lastmod>2026-04-11T17:34:11.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/blog</loc><lastmod>2026-04-11T17:34:11.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/blog/page/1</loc><lastmod>2026-04-11T17:34:11.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/blog/page/2</loc><lastmod>2026-04-11T17:34:11.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/contact</loc><lastmod>2026-04-11T17:34:11.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com/icon.svg</loc><lastmod>2026-04-11T17:34:11.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.metadot.com</loc><lastmod>2026-04-11T17:34:11.346Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://www.metadot.com/blog/2020/10/firstweekremote</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2020/11/successremoteteam</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/01/dresscode</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/01/meetings</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
+<url><loc>https://www.metadot.com/blog/2021/02/coffeedates</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
+<url><loc>https://www.metadot.com/blog/2021/02/deepwork</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/03/360reviews</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/03/buddysystem</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/03/fourattributes</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/04/sittingdisease</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/04/zoomfatigue</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-<url><loc>https://www.metadot.com/blog/2021/02/coffeedates</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-<url><loc>https://www.metadot.com/blog/2021/02/deepwork</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 <url><loc>https://www.metadot.com/blog/2021/05/global</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 </urlset>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -38,7 +38,7 @@ export default function Contact() {
       <section className="py-16 md:py-24 border-b border-[#334155]">
         <div className="container">
           <div className="text-center mb-12">
-            <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#475569] mb-4">
+            <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#94a3b8] mb-4">
               Support
             </p>
             <h1 className="text-3xl md:text-5xl">
@@ -58,14 +58,14 @@ export default function Contact() {
                 <div className="text-[#94a3b8] group-hover:text-[#f0b93c] transition-colors mb-4">
                   {card.icon}
                 </div>
-                <h3 className="text-sm font-semibold text-white mb-auto">
+                <h3 className="text-sm font-semibold text-white">
                   {card.title}
                 </h3>
-                <div className="flex items-center justify-between mt-4 pt-4 border-t border-[#334155]">
-                  <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-[#475569] group-hover:text-[#f0b93c] transition-colors">
+                <div className="flex items-center justify-between mt-auto pt-4 border-t border-[#334155]">
+                  <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-[#94a3b8] group-hover:text-[#f0b93c] transition-colors">
                     Go to support
                   </span>
-                  <FaArrowRight className="w-3 h-3 text-[#475569] group-hover:text-[#f0b93c] group-hover:translate-x-1 transition-all" />
+                  <FaArrowRight className="w-3 h-3 text-[#94a3b8] group-hover:text-[#f0b93c] group-hover:translate-x-1 transition-all" />
                 </div>
               </a>
             ))}

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -35,14 +35,14 @@ export default function Footer() {
                 className="brightness-0 invert"
               />
             </Link>
-            <p className="text-sm text-[#475569] leading-relaxed mt-2">
+            <p className="text-sm text-[#94a3b8] leading-relaxed mt-2">
               Hardware and software products built in Austin, Texas.
             </p>
           </div>
 
           {/* Products */}
           <div>
-            <h4 className="font-mono text-xs font-semibold tracking-[0.15em] uppercase text-[#475569] mb-4">
+            <h4 className="font-mono text-xs font-semibold tracking-[0.15em] uppercase text-[#94a3b8] mb-4">
               Products
             </h4>
             <ul className="space-y-2">
@@ -63,7 +63,7 @@ export default function Footer() {
 
           {/* Company */}
           <div>
-            <h4 className="font-mono text-xs font-semibold tracking-[0.15em] uppercase text-[#475569] mb-4">
+            <h4 className="font-mono text-xs font-semibold tracking-[0.15em] uppercase text-[#94a3b8] mb-4">
               Company
             </h4>
             <ul className="space-y-2">
@@ -82,7 +82,7 @@ export default function Footer() {
 
           {/* Connect */}
           <div>
-            <h4 className="font-mono text-xs font-semibold tracking-[0.15em] uppercase text-[#475569] mb-4">
+            <h4 className="font-mono text-xs font-semibold tracking-[0.15em] uppercase text-[#94a3b8] mb-4">
               Connect
             </h4>
             <div className="flex gap-3">
@@ -105,7 +105,7 @@ export default function Footer() {
                 <FaLinkedin size={16} />
               </Link>
             </div>
-            <p className="text-xs text-[#475569] mt-4 leading-relaxed">
+            <p className="text-xs text-[#94a3b8] mt-4 leading-relaxed">
               Austin, Texas, USA
             </p>
           </div>

--- a/src/sections/Products.tsx
+++ b/src/sections/Products.tsx
@@ -60,7 +60,7 @@ export default function Products() {
                   <span className="font-mono text-base font-semibold text-white">
                     {product.name}
                   </span>
-                  <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-[#475569] border border-[#475569] px-2 py-0.5 rounded-sm">
+                  <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-[#94a3b8] border border-[#475569] px-2 py-0.5 rounded-sm">
                     {product.tag}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- Fix low-contrast text (`#475569` → `#94a3b8`) on product tile badges, footer headings/tagline, and contact page CTAs and "Support" label
- Bottom-align "Go to support" CTA in contact page tiles using `mt-auto`
- Make conductor.json setup script resilient to missing `.env.local` and `.vercel` files

## Test plan
- [ ] Verify product tile badges (TICKETING, CHECKLISTS, etc.) are readable on homepage
- [ ] Verify footer headings (Products, Company, Connect), tagline, and location text are visible
- [ ] Verify contact page "Go to support" CTAs are visible and bottom-aligned across all cards
- [ ] Verify "Support" label on contact page is readable
- [ ] Run `pnpm build` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)