### PR TITLE
Redesign beta page with grid layout and structured sections

### DIFF
--- a/src/app/beta/page.tsx
+++ b/src/app/beta/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Metadot Apps — Private Beta",
   description:
-    "Everything your team needs to work. One suite. No duct tape. Join the Metadot Apps private beta.",
+    "One suite to replace your stack. Join the Metadot Apps private beta.",
   robots: { index: false, follow: false },
 };
 
@@ -14,177 +14,206 @@ const apps = [
   {
     name: "Stackr Projects",
     tag: "Kanban",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
-        <rect x="3" y="3" width="7" height="7" rx="1" />
-        <rect x="14" y="3" width="7" height="7" rx="1" />
-        <rect x="3" y="14" width="7" height="7" rx="1" />
-        <rect x="14" y="14" width="7" height="7" rx="1" />
-      </svg>
-    ),
+    wide: true,
     description:
-      "Stackr Projects gives your team a visual board that makes it clear what\u2019s done, what\u2019s in progress, and what\u2019s stuck. If your team runs on spreadsheets right now, this is built for you.",
+      "Stackr gives your team a visual board that makes it clear what\u2019s done, what\u2019s in progress, and what\u2019s stuck. If your team runs on spreadsheets right now, this is built for you.",
   },
   {
     name: "BookMe",
     tag: "Scheduling",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
-        <rect x="3" y="4" width="18" height="18" rx="2" />
-        <line x1="16" y1="2" x2="16" y2="6" />
-        <line x1="8" y1="2" x2="8" y2="6" />
-        <line x1="3" y1="10" x2="21" y2="10" />
-      </svg>
-    ),
     description:
       "BookMe eliminates the scheduling back-and-forth. Share a link, let people pick a time. Works for internal meetings, customer appointments, service calls, and consultations.",
   },
   {
     name: "Changelog",
     tag: "Updates",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
-        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-        <polyline points="14 2 14 8 20 8" />
-        <line x1="8" y1="13" x2="16" y2="13" />
-        <line x1="8" y1="17" x2="12" y2="17" />
-      </svg>
-    ),
     description:
-      "Changelog gives you a single, searchable record of what changed: policies, procedures, system updates, tool rollouts. When IT pushes updates, HR revises a policy, or your call center changes procedures, this is where it lives so nobody has to ask again.",
+      "Changelog gives you a single, searchable record of what changed \u2014 policies, procedures, system updates, tool rollouts. So nobody has to ask again.",
   },
   {
     name: "Workflows",
     tag: "Automation",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
-        <polyline points="17 1 21 5 17 9" />
-        <path d="M3 11V9a4 4 0 0 1 4-4h14" />
-        <polyline points="7 23 3 19 7 15" />
-        <path d="M21 13v2a4 4 0 0 1-4 4H3" />
-      </svg>
-    ),
     description:
       "Workflows automates the handoffs between apps so work moves on its own. No manual steps, no third-party tools connecting things together.",
   },
   {
-    name: "AI assistant",
+    name: "AI Assistant",
     tag: "Built in",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
-        <circle cx="12" cy="12" r="3" />
-        <path d="M12 2v3M12 19v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M2 12h3M19 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12" />
-      </svg>
-    ),
     description:
-      "The AI assistant works across the whole suite. Ask it to create a board for a project, surface what\u2019s overdue, or answer questions about your data.",
+      "The AI assistant works across the whole suite. Ask it to create a board, surface what\u2019s overdue, or answer questions about your data.",
   },
 ];
 
 const comingSoon = [
-  { name: "Assets", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5"><rect x="2" y="7" width="20" height="14" rx="2" /><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2" /></svg> },
-  { name: "CRM", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></svg> },
-  { name: "Inventory", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5"><path d="M21 16V8a2 2 0 0 0-1-1.73L13 2.27a2 2 0 0 0-2 0L4 6.27A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" /><polyline points="3.27 6.96 12 12.01 20.73 6.96" /><line x1="12" y1="22.08" x2="12" y2="12" /></svg> },
-  { name: "InvoiceMe", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5"><line x1="12" y1="1" x2="12" y2="23" /><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" /></svg> },
-  { name: "Knowledge base", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" /><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" /></svg> },
-  { name: "Polls", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5"><line x1="18" y1="20" x2="18" y2="10" /><line x1="12" y1="20" x2="12" y2="4" /><line x1="6" y1="20" x2="6" y2="14" /></svg> },
-  { name: "Suppliers", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5"><rect x="1" y="3" width="15" height="13" /><polygon points="16 8 20 8 23 11 23 16 16 16 16 8" /><circle cx="5.5" cy="18.5" r="2.5" /><circle cx="18.5" cy="18.5" r="2.5" /></svg> },
-  { name: "Tickets", icon: <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5"><path d="M15 5v2" /><path d="M15 11v2" /><path d="M15 17v2" /><path d="M5 5h14a2 2 0 0 1 2 2v3a2 2 0 0 0 0 4v3a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-3a2 2 0 0 0 0-4V7a2 2 0 0 1 2-2z" /></svg> },
+  "Assets",
+  "CRM",
+  "Inventory",
+  "InvoiceMe",
+  "Knowledge base",
+  "Polls",
+  "Suppliers",
+  "Tickets",
 ];
+
+const painPoints = [
+  "Projects tracked in spreadsheets nobody updates",
+  "Scheduling still happening over email",
+  "Policy changes buried in a Slack thread",
+  "Manual handoffs eating up everyone\u2019s time",
+];
+
+function Separator({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-4 my-10">
+      <div className="flex-1 h-px bg-[#334155]" />
+      <span className="font-mono text-[10px] font-semibold tracking-[0.2em] uppercase text-[#64748b] whitespace-nowrap">
+        {label}
+      </span>
+      <div className="flex-1 h-px bg-[#334155]" />
+    </div>
+  );
+}
 
 export default function BetaPage() {
   return (
-    <div className="max-w-[720px] mx-auto px-6 pt-12 pb-20">
+    <div className="max-w-[960px] mx-auto px-6 pt-16 pb-20">
       {/* Hero */}
-      <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#94a3b8] mb-3">
-        Metadot Apps
-      </p>
-      <h1 className="text-4xl md:text-5xl font-bold leading-tight mb-4">
-        Everything your team needs to work.{" "}
-        <em className="font-bold text-[#f0b93c] not-italic">One suite.</em> No duct tape.
-      </h1>
+      <section className="text-center mb-6">
+        <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#f0b93c] mb-4">
+          Metadot Apps &mdash; Private Beta
+        </p>
+        <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold leading-[1.05] tracking-tight mb-3">
+          One suite to replace
+          <br />
+          your stack.
+        </h1>
+        <p className="font-mono text-sm md:text-base font-semibold tracking-[0.12em] uppercase text-[#94a3b8] mb-6">
+          Everything your team needs to work. No duct tape.
+        </p>
+        <p className="text-base leading-relaxed text-[#94a3b8] max-w-[480px] mx-auto mb-8">
+          Metadot replaces the five tools that don&apos;t talk to each
+          other&mdash;projects, scheduling, change communication, automation, and
+          AI, all in one place.
+        </p>
+        <div className="flex items-center gap-4 justify-center flex-wrap mb-6">
+          <a
+            href={POLL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-primary btn"
+          >
+            Join the private beta
+          </a>
+          <a href="#suite-section" className="btn">
+            Explore the suite &darr;
+          </a>
+        </div>
+        <p className="font-mono text-[10px] font-semibold tracking-[0.14em] uppercase text-[#64748b]">
+          Built by the team behind{" "}
+          <a
+            href="https://www.mojohelpdesk.com"
+            className="text-[#94a3b8] no-underline border-b border-[#475569] hover:text-[#f0b93c] hover:border-[#f0b93c] transition-colors"
+          >
+            Mojo Helpdesk
+          </a>
+        </p>
+      </section>
 
-      <p className="text-lg leading-relaxed text-[#94a3b8] mb-10 max-w-[540px]">
-        Metadot replaces the five tools that don&apos;t talk to each
-        other&mdash;projects, scheduling, change communication, automation, and
-        AI, all in one place.
-      </p>
+      {/* Why it exists */}
+      <Separator label="Why it exists" />
 
-      <div className="flex items-center gap-4 flex-wrap mb-16">
-        <a
-          href={POLL_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="btn"
-        >
-          Join the private beta
-        </a>
-      </div>
-
-      {/* Divider */}
-      <hr className="border-t border-[#334155] mb-11" />
+      <section className="grid grid-cols-1 md:grid-cols-[1fr_1.6fr] gap-8 mb-6">
+        <div>
+          <h3 className="text-xl md:text-2xl font-bold leading-snug text-white mb-1">
+            Built for teams tired of duct tape.
+          </h3>
+          <p className="text-base md:text-lg font-semibold text-[#64748b]">
+            One place. Everything connected.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2">
+          {painPoints.map((point) => (
+            <div
+              key={point}
+              className="flex items-start gap-2.5 py-3 pr-2 border-b border-[#1e293b] text-sm text-[#94a3b8] leading-relaxed"
+            >
+              <span className="text-red-500 font-bold text-xs mt-0.5 shrink-0">&times;</span>
+              {point}
+            </div>
+          ))}
+        </div>
+      </section>
 
       {/* What's in the suite */}
-      <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#94a3b8] mb-6">
-        WHAT&apos;S IN THE SUITE
-      </p>
+      <Separator label="What&rsquo;s in the suite" />
 
-      <div className="flex flex-col gap-3 mb-10">
-        {apps.map((app) => (
-          <div
-            key={app.name}
-            className="p-6 bg-[#1e293b] border border-[#334155] rounded-sm hover:border-[#475569] transition-colors"
-          >
-            <div className="flex items-center gap-3 mb-3">
-              <span className="text-[#94a3b8]">{app.icon}</span>
-              <span className="font-mono text-base font-semibold text-white">{app.name}</span>
-              <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-[#94a3b8] border border-[#94a3b8] px-2 py-0.5 rounded-sm ml-auto">
+      <section className="mb-6" id="suite-section">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 border-t border-l border-[#334155]">
+          {apps.map((app) => (
+            <div
+              key={app.name}
+              className={`border-b border-r border-[#334155] p-6 lg:p-8 hover:bg-[#1e293b] transition-colors${
+                app.wide ? " sm:col-span-2" : ""
+              }`}
+            >
+              <span className="font-mono text-[10px] font-semibold tracking-[0.16em] uppercase text-[#f0b93c] mb-3 block">
                 {app.tag}
               </span>
+              <div className="font-bold text-xl tracking-tight leading-tight text-white mb-3">
+                {app.name}
+              </div>
+              <p className="text-sm leading-relaxed text-[#94a3b8] mb-0">
+                {app.description}
+              </p>
             </div>
-            <p className="text-sm leading-relaxed text-[#94a3b8]">
-              {app.description}
-            </p>
-          </div>
-        ))}
-      </div>
-
-      {/* Divider */}
-      <hr className="border-t border-[#334155] mb-11" />
+          ))}
+        </div>
+      </section>
 
       {/* Coming soon */}
-      <p className="font-mono text-xs font-semibold tracking-[0.2em] uppercase text-[#94a3b8] mb-6">
-        COMING SOON
-      </p>
-      <div className="flex flex-wrap gap-2 mb-14">
-        {comingSoon.map((item) => (
-          <span
-            key={item.name}
-            className="inline-flex items-center gap-1.5 text-sm text-[#94a3b8] bg-[#1e293b] border border-[#334155] rounded-full px-3.5 py-1"
-          >
-            {item.icon}
-            {item.name}
+      <Separator label="Coming soon" />
+
+      <section className="bg-[#1e293b] border border-[#334155] py-5 px-6 mb-6">
+        <div className="flex items-center gap-6 flex-wrap">
+          <span className="font-mono text-[10px] font-semibold tracking-[0.18em] uppercase text-[#64748b] whitespace-nowrap">
+            In development
           </span>
-        ))}
-      </div>
+          <div className="flex gap-2 flex-wrap">
+            {comingSoon.map((item) => (
+              <span
+                key={item}
+                className="font-mono text-[10px] font-semibold tracking-[0.1em] uppercase text-[#94a3b8] border border-[#475569] px-3 py-1"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+      </section>
 
       {/* Bottom CTA */}
-      <div className="rounded-sm p-8 bg-[#1e293b] border border-[#334155]" id="beta-section">
-        <h2 className="!text-2xl font-bold mb-2 text-white">Join the private beta</h2>
-        <p className="text-xs text-[#94a3b8] leading-relaxed mb-6">
-          Metadot Apps is in active development. Private beta participants get
-          first access and shape what gets built. Spots are limited.
+      <Separator label="" />
+
+      <section className="text-center py-12" id="beta-section">
+        <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold leading-tight tracking-tight text-white mb-4">
+          Metadot Apps is in active development.
+          <br />
+          <em className="not-italic text-[#f0b93c]">
+            Private beta participants shape what gets built.
+          </em>
+        </h2>
+        <p className="text-[15px] text-[#94a3b8] max-w-[400px] mx-auto mb-8 leading-relaxed">
+          First access. Limited spots. No commitment.
         </p>
         <a
           href={POLL_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="btn"
+          className="btn btn-primary"
         >
           Request a spot
         </a>
-
-      </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Redesign beta page to match new mockup layout while keeping dark theme
- Replace vertical card stack with 3-column bordered product grid (responsive: 3→2→1 cols)
- Add separator lines, problem/pain-points band, dual CTAs, and centered CTA band
- Remove unused SVG icons from app data, simplify coming-soon chips

## Test plan
- [ ] Visual check at desktop (1280px), tablet (768px), and mobile (375px)
- [ ] Verify grid borders don't double at any breakpoint
- [ ] Verify CTA links point to correct poll URL
- [ ] Check tile hover states

🤖 Generated with [Claude Code](https://claude.com/claude-code)